### PR TITLE
Make PHOEBE/SPICE eclipse mesh resolution configurable

### DIFF
--- a/tutorial/paper_results/check_phoebe_eclipses.pbs
+++ b/tutorial/paper_results/check_phoebe_eclipses.pbs
@@ -79,27 +79,34 @@ mkdir -p "${OUTPUT_DIR}"
 # ---------------------------------------------------------------------------
 # If the user already has a grid CSV, point GRID_CSV at it and skip generation.
 # Otherwise build a default sweep here. Columns: inclination,period,q,ecc,
-# primary_mass,n_times.
+# primary_mass,n_times,n_mesh_elements.
+#
+# N_MESH_ELEMENTS sets both the SPICE icosphere subdivision count and PHOEBE's
+# ntriangles, so the two codes are compared at matching surface resolution.
+N_MESH_ELEMENTS="${N_MESH_ELEMENTS:-1000}"
 if [[ ! -s "${GRID_CSV}" ]]; then
-    python3 - "${GRID_CSV}" <<'PY'
-import csv, sys
+    N_MESH_ELEMENTS="${N_MESH_ELEMENTS}" python3 - "${GRID_CSV}" <<'PY'
+import csv, os, sys
 import numpy as np
 
-inclinations  = [85.0, 90.0]        # degrees
-periods       = np.linspace(2.0, 100.0, 10)         # days
-qs            = np.linspace(0.5, 1.0, 5)
-eccs          = np.linspace(0.0, 0.8, 5)
-primary_mass  = 1.0
-n_times       = 20
+inclinations    = [85.0, 90.0]        # degrees
+periods         = np.linspace(2.0, 100.0, 10)         # days
+qs              = np.linspace(0.5, 1.0, 5)
+eccs            = np.linspace(0.0, 0.8, 5)
+primary_mass    = 1.0
+n_times         = 20
+n_mesh_elements = int(os.environ["N_MESH_ELEMENTS"])
 
 with open(sys.argv[1], "w", newline="") as f:
     w = csv.writer(f)
-    w.writerow(["inclination", "period", "q", "ecc", "primary_mass", "n_times"])
+    w.writerow(["inclination", "period", "q", "ecc", "primary_mass", "n_times",
+                "n_mesh_elements"])
     for incl in inclinations:
         for P in periods:
             for q in qs:
                 for e in eccs:
-                    w.writerow([f"{incl:.4f}", f"{P:.4f}", q, e, primary_mass, n_times])
+                    w.writerow([f"{incl:.4f}", f"{P:.4f}", q, e, primary_mass,
+                                n_times, n_mesh_elements])
 PY
     echo "Generated grid: ${GRID_CSV}"
 fi

--- a/tutorial/paper_results/check_phoebe_eclipses.py
+++ b/tutorial/paper_results/check_phoebe_eclipses.py
@@ -8,8 +8,8 @@ Grid mode (multiprocessing across a CSV of parameter sets):
     python check_phoebe_eclipses.py --grid-config grid.csv \
         --n-workers 16 --output_path lc_eclipse
 
-CSV columns (header required): inclination,period[,q,ecc,primary_mass,n_times].
-Missing optional columns fall back to the corresponding CLI flags.
+CSV columns (header required): inclination,period[,q,ecc,primary_mass,n_times,
+n_mesh_elements]. Missing optional columns fall back to the corresponding CLI flags.
 
 Each worker builds one PHOEBE default_binary() at startup and reuses it for
 every task — only parameter values and dataset times are updated between
@@ -123,12 +123,12 @@ def _ensure_datasets(b, times):
         b.set_value_all('compute_times', dataset='lc_bolometric', value=times)
 
 
-def _default_icosphere(mass, bb):
+def _default_icosphere(mass, bb, n_elements):
     from spice.models.binary import Binary  # noqa: F401 - touch to warm import
     from spice.models.mesh_model import IcosphereModel
     from spice.models.mesh_view import get_mesh_view
     return get_mesh_view(
-        IcosphereModel.construct(1000, 1., mass, bb.solar_parameters, bb.parameter_names),
+        IcosphereModel.construct(n_elements, 1., mass, bb.solar_parameters, bb.parameter_names),
         jnp.array([0., 0., -1.]),
     )
 
@@ -149,7 +149,7 @@ def init_worker():
     _WORKER['bol'] = Bolometric()
 
 
-def run_one(inclination, period, q, ecc, n_times, primary_mass, output_path):
+def run_one(inclination, period, q, ecc, n_times, primary_mass, n_mesh_elements, output_path):
     """Run a single grid point, reusing the worker's PHOEBE bundle."""
     from spice.models.binary import Binary, add_orbit, evaluate_orbit_at_times
     from spice.models.orbit_utils import eclipse_timestamps_kepler
@@ -166,7 +166,7 @@ def run_one(inclination, period, q, ecc, n_times, primary_mass, output_path):
     output_path.mkdir(parents=True, exist_ok=True)
     out_pkl = output_path / (
         f'eclipses_incl_{inclination}_period_{period}_q_{q}_ecc_{ecc}'
-        f'_primary_mass_{primary_mass}.pkl'
+        f'_primary_mass_{primary_mass}_nmesh_{n_mesh_elements}.pkl'
     )
     if out_pkl.exists():
         print(f"[skip] {out_pkl.name}")
@@ -216,12 +216,12 @@ def run_one(inclination, period, q, ecc, n_times, primary_mass, output_path):
     _ensure_datasets(b, times)
     b.compute_pblums(pbflux=True, set_value=True)
     b.compute_ld_coeffs(ld_mode='manual', ld_func='linear', ld_coeffs=[0.])
-    b.run_compute(irrad_method='none', coordinates='uvw', ltte=False, ntriangles=20000)
+    b.run_compute(irrad_method='none', coordinates='uvw', ltte=False, ntriangles=n_mesh_elements)
 
     fluxes_phoebe = np.asarray(b.get_parameter('fluxes@lc_bolometric@model').value)
 
-    body1 = _default_icosphere(b.get_parameter('mass@primary@component').value, bb)
-    body2 = _default_icosphere(b.get_parameter('mass@secondary@component').value, bb)
+    body1 = _default_icosphere(b.get_parameter('mass@primary@component').value, bb, n_mesh_elements)
+    body2 = _default_icosphere(b.get_parameter('mass@secondary@component').value, bb, n_mesh_elements)
     binary = Binary.from_bodies(body1, body2)
     binary = add_orbit(
         binary,
@@ -264,6 +264,7 @@ def run_one(inclination, period, q, ecc, n_times, primary_mass, output_path):
             'period': period,
             'q': q,
             'ecc': ecc,
+            'n_mesh_elements': n_mesh_elements,
         }, f)
 
     # Bound JAX cache + Python heap growth across many tasks per worker
@@ -326,6 +327,7 @@ def _read_grid_csv(path, defaults):
                 'ecc': float(r.get('ecc') or defaults['ecc']),
                 'primary_mass': float(r.get('primary_mass') or defaults['primary_mass']),
                 'n_times': int(r.get('n_times') or defaults['n_times']),
+                'n_mesh_elements': int(r.get('n_mesh_elements') or defaults['n_mesh_elements']),
             })
     return rows
 
@@ -342,6 +344,10 @@ def main():
     parser.add_argument('--primary_mass', type=float, default=1.0, help='Primary mass [Msun]')
     parser.add_argument('--n_times', type=int, default=10,
                         help='Time points per run (split evenly between primary/secondary eclipse).')
+    parser.add_argument('--n_mesh_elements', type=int, default=1000,
+                        help='Surface mesh resolution. Sets both the SPICE icosphere subdivision '
+                             'count and PHOEBE ntriangles so the two codes are compared at '
+                             'matching resolution.')
     parser.add_argument('--output_path', type=str, default='lc_eclipse',
                         help='Output directory for per-run pickles.')
     parser.add_argument('--grid-config', type=Path, default=None,
@@ -351,7 +357,7 @@ def main():
     args = parser.parse_args()
 
     defaults = {'q': args.q, 'ecc': args.ecc, 'primary_mass': args.primary_mass,
-                'n_times': args.n_times}
+                'n_times': args.n_times, 'n_mesh_elements': args.n_mesh_elements}
 
     if args.grid_config is not None:
         tasks = _read_grid_csv(args.grid_config, defaults)
@@ -384,7 +390,7 @@ def main():
 
     init_worker()
     run_one(args.inclination, args.period, args.q, args.ecc,
-            args.n_times, args.primary_mass, args.output_path)
+            args.n_times, args.primary_mass, args.n_mesh_elements, args.output_path)
 
 
 if __name__ == '__main__':

--- a/tutorial/paper_results/phoebe_spice_comparison/single_eclipse_system.ipynb
+++ b/tutorial/paper_results/phoebe_spice_comparison/single_eclipse_system.ipynb
@@ -1,0 +1,408 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Single PHOEBE + SPICE eclipse system\n",
+    "\n",
+    "Builds **one** binary the same way `check_phoebe_eclipses.py` does, runs both PHOEBE and SPICE on the eclipse window, and plots the bolometric light curves side by side.\n",
+    "\n",
+    "Useful for interactive exploration / plot tweaks without launching the full grid."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "env-setup",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ.setdefault('XLA_PYTHON_CLIENT_PREALLOCATE', 'false')\n",
+    "os.environ.setdefault('XLA_PYTHON_CLIENT_ALLOCATOR', 'platform')\n",
+    "\n",
+    "import jax\n",
+    "jax.config.update('jax_enable_x64', True)\n",
+    "jax.config.update('jax_platform_name', 'cpu')\n",
+    "\n",
+    "import sys\n",
+    "sys.path.append('/Users/mjablons/code/spice/src')\n",
+    "\n",
+    "import numpy as np\n",
+    "import jax.numpy as jnp\n",
+    "import matplotlib.pyplot as plt\n",
+    "from astropy import units as u\n",
+    "\n",
+    "import phoebe\n",
+    "from phoebe.parameters.dataset import _mesh_columns\n",
+    "\n",
+    "from spice.models.binary import Binary, add_orbit, evaluate_orbit_at_times\n",
+    "from spice.models.mesh_model import IcosphereModel\n",
+    "from spice.models.mesh_view import get_mesh_view\n",
+    "from spice.models.orbit_utils import eclipse_timestamps_kepler\n",
+    "from spice.spectrum.blackbody import Blackbody\n",
+    "from spice.spectrum.filter import Bolometric\n",
+    "from spice.spectrum.spectrum import AB_passband_luminosity, simulate_observed_flux\n",
+    "\n",
+    "%matplotlib inline\n",
+    "\n",
+    "DAYS_TO_YR = 0.0027378507871321013\n",
+    "DEG_TO_RAD = 0.017453292519943295"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "params-md",
+   "metadata": {},
+   "source": [
+    "## Parameters\n",
+    "\n",
+    "Edit these to explore other geometries. Defaults match a clean, fully eclipsing case."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "params",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inclination     = 90.0   # degrees\n",
+    "period          = 5.0    # days\n",
+    "q               = 1.0    # mass ratio\n",
+    "ecc             = 0.0    # eccentricity\n",
+    "primary_mass    = 1.0    # Msun\n",
+    "n_times         = 40     # samples (split evenly between primary/secondary eclipse)\n",
+    "n_mesh_elements = 1000   # both SPICE icosphere and PHOEBE ntriangles"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "phoebe-md",
+   "metadata": {},
+   "source": [
+    "## Build PHOEBE bundle and pick the eclipse window\n",
+    "\n",
+    "We use SPICE's `eclipse_timestamps_kepler` to find the primary and secondary eclipse contact times so PHOEBE only computes inside the windows of interest."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "build-bundle",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phoebe.multiprocessing_set_nprocs(1)\n",
+    "\n",
+    "b = phoebe.default_binary()\n",
+    "b.flip_constraint('mass@primary', solve_for='sma')\n",
+    "#b.set_value_all('ntriangles@primary', 5000)\n",
+    "b.set_value('period@binary@component', period)\n",
+    "b.set_value('q@binary@component', q)\n",
+    "b.set_value('ecc@binary@component', ecc)\n",
+    "b.set_value('mass@primary@component', primary_mass)\n",
+    "b.set_value_all('incl@binary', inclination)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "eclipse-window",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Primary eclipse window  [d]: -0.1027 - 0.1027\n",
+      "Secondary eclipse window [d]: 2.3973 - 2.6027\n"
+     ]
+    }
+   ],
+   "source": [
+    "_, t1_p, _, _, t4_p, _, t1_s, _, _, t4_s = eclipse_timestamps_kepler(\n",
+    "    b.get_parameter('mass@primary@component').value,\n",
+    "    b.get_parameter('mass@secondary@component').value,\n",
+    "    b.get_parameter('period@binary@component').value * DAYS_TO_YR,\n",
+    "    b.get_parameter('ecc@binary@component').value,\n",
+    "    b.get_parameter('t0_perpass@binary@component').value * DAYS_TO_YR,\n",
+    "    jnp.deg2rad(b.get_parameter('incl@binary@component').value),\n",
+    "    b.get_parameter('per0@binary@component').value * DEG_TO_RAD,\n",
+    "    b.get_parameter('long_an@binary@component').value * DAYS_TO_YR,\n",
+    "    b.get_parameter('requiv@primary@component').value,\n",
+    "    b.get_parameter('requiv@secondary@component').value,\n",
+    "    pad=1.1,\n",
+    "    los_vector=jnp.array([0., 0., -1.]),\n",
+    ")\n",
+    "\n",
+    "eclipse_edges = (float(t1_p), float(t4_p), float(t1_s), float(t4_s))\n",
+    "if not all(np.isfinite(eclipse_edges)):\n",
+    "    raise RuntimeError(f'No eclipse for this geometry: edges={eclipse_edges}')\n",
+    "\n",
+    "half = int(n_times / 2)\n",
+    "times = np.concatenate([\n",
+    "    np.linspace(eclipse_edges[0] / DAYS_TO_YR, eclipse_edges[1] / DAYS_TO_YR, half),\n",
+    "    np.linspace(eclipse_edges[2] / DAYS_TO_YR, eclipse_edges[3] / DAYS_TO_YR, half),\n",
+    "])\n",
+    "times_yr = times * DAYS_TO_YR\n",
+    "print(f'Primary eclipse window  [d]: {eclipse_edges[0] / DAYS_TO_YR:.4f} - {eclipse_edges[1] / DAYS_TO_YR:.4f}')\n",
+    "print(f'Secondary eclipse window [d]: {eclipse_edges[2] / DAYS_TO_YR:.4f} - {eclipse_edges[3] / DAYS_TO_YR:.4f}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "phoebe-datasets",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 40/40 [00:05<00:00,  7.67it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "b.add_dataset('mesh', compute_times=times, columns=_mesh_columns, dataset='mesh01')\n",
+    "b.add_dataset('orb', compute_times=times, dataset='orb01')\n",
+    "b.add_dataset('lc', compute_times=times,\n",
+    "              passband='Bolometric:900-40000', dataset='lc_bolometric')\n",
+    "b.set_value_all('pblum_mode', dataset='lc_bolometric', value='absolute')\n",
+    "b.set_value('distance', 10 * u.pc)\n",
+    "b.set_value_all('ld_mode', 'manual')\n",
+    "b.set_value_all('ld_func', 'linear')\n",
+    "b.set_value_all('ld_coeffs', [0.])\n",
+    "b.set_value_all('ld_mode_bol', 'manual')\n",
+    "b.set_value_all('ld_func_bol', 'linear')\n",
+    "b.set_value_all('ld_coeffs_bol', [0.])\n",
+    "b.set_value_all('atm', 'blackbody')\n",
+    "b.set_value_all('irrad_method', 'none')\n",
+    "b.set_value_all('gravb_bol', 0.0)\n",
+    "\n",
+    "b.compute_pblums(pbflux=True, set_value=True)\n",
+    "b.compute_ld_coeffs(ld_mode='manual', ld_func='linear', ld_coeffs=[0.])\n",
+    "b.run_compute(irrad_method='none', coordinates='uvw', ltte=False, ntriangles=n_mesh_elements)\n",
+    "\n",
+    "fluxes_phoebe = np.asarray(b.get_parameter('fluxes@lc_bolometric@model').value)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "8b6a8ea7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5746"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(b.get_value('us@primary', time=times[0]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "spice-md",
+   "metadata": {},
+   "source": [
+    "## SPICE bolometric light curve\n",
+    "\n",
+    "Same orbital parameters, blackbody atmosphere, no limb darkening — matched as closely as possible to the PHOEBE setup above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "spice-build",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bb = Blackbody()\n",
+    "bol = Bolometric()\n",
+    "\n",
+    "def default_icosphere(mass):\n",
+    "    return get_mesh_view(\n",
+    "        IcosphereModel.construct(n_mesh_elements, 1., mass,\n",
+    "                                 bb.solar_parameters, bb.parameter_names),\n",
+    "        jnp.array([0., 0., -1.]),\n",
+    "    )\n",
+    "\n",
+    "body1 = default_icosphere(b.get_parameter('mass@primary@component').value)\n",
+    "body2 = default_icosphere(b.get_parameter('mass@secondary@component').value)\n",
+    "binary = Binary.from_bodies(body1, body2)\n",
+    "binary = add_orbit(\n",
+    "    binary,\n",
+    "    P=b.get_parameter('period@binary@component').value * DAYS_TO_YR,\n",
+    "    ecc=b.get_parameter('ecc@binary@component').value,\n",
+    "    T=b.get_parameter('t0_perpass@binary@component').value * DAYS_TO_YR,\n",
+    "    i=jnp.deg2rad(b.get_parameter('incl@binary@component').value),\n",
+    "    omega=b.get_parameter('per0@binary@component').value * DEG_TO_RAD,\n",
+    "    Omega=b.get_parameter('long_an@binary@component').value * DAYS_TO_YR,\n",
+    "    vgamma=b.get_parameter('vgamma').value,\n",
+    "    reference_time=b.get_parameter('t0_ref@binary@component').value * DAYS_TO_YR,\n",
+    "    mean_anomaly=b.get_parameter('mean_anom@binary@component').value * DEG_TO_RAD,\n",
+    "    orbit_resolution_points=len(times_yr),\n",
+    ")\n",
+    "\n",
+    "pb1, pb2 = evaluate_orbit_at_times(binary, times_yr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "spice-spectra",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vws = jnp.linspace(900, 40000, 1000)\n",
+    "log_vws = jnp.log10(vws)\n",
+    "\n",
+    "bol_lum = []\n",
+    "for _pb1, _pb2 in zip(pb1, pb2):\n",
+    "    spec1 = simulate_observed_flux(bb.intensity, _pb1, log_vws, disable_doppler_shift=True)\n",
+    "    spec2 = simulate_observed_flux(bb.intensity, _pb2, log_vws, disable_doppler_shift=True)\n",
+    "    bol_lum.append(AB_passband_luminosity(bol, vws, spec1[:, 0] + spec2[:, 0]))\n",
+    "bol_lum = np.array(bol_lum)\n",
+    "spice_mag = bol_lum - bol_lum[0]\n",
+    "\n",
+    "phoebe_mag_raw = -2.5 * np.log10(np.asarray(fluxes_phoebe, dtype=float))\n",
+    "phoebe_mag = phoebe_mag_raw - phoebe_mag_raw[0]\n",
+    "residual = spice_mag - phoebe_mag"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "plot-md",
+   "metadata": {},
+   "source": [
+    "## Plot the comparison\n",
+    "\n",
+    "Top row: PHOEBE vs SPICE bolometric magnitudes (zeroed at $t_0$).\n",
+    "Bottom row: SPICE - PHOEBE residual."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "plot",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "t_primary   = times[:half]\n",
+    "t_secondary = times[half:]\n",
+    "\n",
+    "fig, axes = plt.subplots(2, 2, figsize=(12, 7), sharex='col', sharey='row',\n",
+    "                         gridspec_kw={'height_ratios': [3, 1], 'hspace': 0.05, 'wspace': 0.15})\n",
+    "\n",
+    "for ax_lc, ax_res, t, sl, title in (\n",
+    "    (axes[0, 0], axes[1, 0], t_primary,   slice(0, half),  'Primary eclipse'),\n",
+    "    (axes[0, 1], axes[1, 1], t_secondary, slice(half, None), 'Secondary eclipse'),\n",
+    "):\n",
+    "    ax_lc.plot(t, phoebe_mag[sl], 'o-', label='PHOEBE', color='black')\n",
+    "    ax_lc.plot(t, spice_mag[sl],  's--', label='SPICE',  color='firebrick')\n",
+    "    ax_lc.invert_yaxis()\n",
+    "    ax_lc.set_title(title)\n",
+    "    ax_lc.grid(alpha=0.3)\n",
+    "\n",
+    "    ax_res.axhline(0, color='gray', lw=0.7)\n",
+    "    ax_res.plot(t, residual[sl], 'o-', color='steelblue')\n",
+    "    ax_res.set_xlabel('Time [days]')\n",
+    "    ax_res.grid(alpha=0.3)\n",
+    "\n",
+    "axes[0, 0].set_ylabel(r'$\\Delta$ mag (zeroed at $t_0$)')\n",
+    "axes[1, 0].set_ylabel('SPICE - PHOEBE [mag]')\n",
+    "axes[0, 0].legend(loc='best')\n",
+    "fig.suptitle(\n",
+    "    f'incl={inclination}, P={period} d, q={q}, ecc={ecc}, '\n",
+    "    f'm1={primary_mass}, n_mesh={n_mesh_elements}'\n",
+    ")\n",
+    "plt.show()\n",
+    "\n",
+    "print(f'max |residual| = {np.nanmax(np.abs(residual)):.4e} mag')\n",
+    "print(f'rms residual   = {np.sqrt(np.nanmean(residual**2)):.4e} mag')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "save-md",
+   "metadata": {},
+   "source": [
+    "## (Optional) Save in the same pickle layout as the grid script\n",
+    "\n",
+    "Useful if you want to drop the result into the existing `blackbody_comparison.ipynb` loader."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "save",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pickle\n",
+    "from pathlib import Path\n",
+    "\n",
+    "SAVE = False  # flip to True to write the pickle\n",
+    "OUTPUT_PATH = Path('lc_eclipse')\n",
+    "\n",
+    "if SAVE:\n",
+    "    OUTPUT_PATH.mkdir(parents=True, exist_ok=True)\n",
+    "    out_pkl = OUTPUT_PATH / (\n",
+    "        f'eclipses_incl_{inclination}_period_{period}_q_{q}_ecc_{ecc}'\n",
+    "        f'_primary_mass_{primary_mass}_nmesh_{n_mesh_elements}.pkl'\n",
+    "    )\n",
+    "    with open(out_pkl, 'wb') as f:\n",
+    "        pickle.dump({\n",
+    "            'phoebe_binary': b,\n",
+    "            'spice_body1': pb1,\n",
+    "            'spice_body2': pb2,\n",
+    "            'fluxes_phoebe': fluxes_phoebe,\n",
+    "            'bol_lum': spice_mag,\n",
+    "            'times': times,\n",
+    "            'n_times': n_times,\n",
+    "            'sma': b.get_parameter('sma@binary@component').value,\n",
+    "            'primary_mass': primary_mass,\n",
+    "            'secondary_mass': b.get_parameter('mass@secondary@component').value,\n",
+    "            'inclination': inclination,\n",
+    "            'period': period,\n",
+    "            'q': q,\n",
+    "            'ecc': ecc,\n",
+    "            'n_mesh_elements': n_mesh_elements,\n",
+    "        }, f)\n",
+    "    print(f'wrote {out_pkl}')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "astro",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Adds an --n_mesh_elements CLI flag (and matching CSV column / PBS env var) that drives both the SPICE icosphere subdivision count and PHOEBE's ntriangles, so the two codes are compared at matching surface resolution instead of hard-coded 1000 vs 20000. Output filenames now include the mesh count so different resolutions don't overwrite each other.

Also adds phoebe_spice_comparison/single_eclipse_system.ipynb, an interactive single-system version of check_phoebe_eclipses.py for plotting and parameter exploration.