### PR TITLE
TZ Fornacis: predict eclipse windows + GPU lightcurve script

### DIFF
--- a/tutorial/paper_results/tz_fornacis/tz_fornacis_lightcurves.pbs
+++ b/tutorial/paper_results/tz_fornacis/tz_fornacis_lightcurves.pbs
@@ -1,0 +1,145 @@
+#!/bin/bash
+#============================================================================
+#  Gadi PBS job — synthesize TZ Fornacis lightcurves (general + eclipse) on
+#  one GPU.
+#
+#  Runs `tz_fornacis_lightcurves.py`, which writes one pickle per sweep:
+#      <OUTPUT_DIR>/tz_fornacis_data_general_<NW>.pkl
+#      <OUTPUT_DIR>/tz_fornacis_data_eclipses_<NW>.pkl
+#  matching the file convention used by `tz_fornacis_lightcurve_plot.ipynb`.
+#  Already-finished pickles are skipped (resubmit to continue after a
+#  walltime hit).
+#
+#  USAGE
+#    1. Edit the "EDIT" lines below: project code (-P), queue (-q), storage,
+#       PYTHON_BIN, and (optionally) the CUDA module load.
+#    2. Submit:   qsub tutorial/paper_results/tz_fornacis/tz_fornacis_lightcurves.pbs
+#       Override knobs at submit time, e.g.:
+#         qsub -v MODE=eclipse,NUM_WAVELENGTHS=100000,NUM_ECLIPSE_TIMES=200 \
+#              tutorial/paper_results/tz_fornacis/tz_fornacis_lightcurves.pbs
+#         qsub -v FORCE=1 tutorial/paper_results/tz_fornacis/tz_fornacis_lightcurves.pbs
+#    3. Monitor:  qstat -fx <jobid>  ;  tail -f tz_fornacis_lightcurves.o<jobid>
+#    4. Restart:  just resubmit — already-finished per-mode pickles are skipped
+#                 unless you pass FORCE=1.
+#
+#  RESOURCE NOTES (gpuvolta)
+#    * ncpus must be a multiple of 12 and ngpus = ncpus/12; mem <= ~96 GB per
+#      GPU. One V100 is plenty — the emulator + binary mesh easily fit.
+#    * Most of the walltime is XLA compilation on first call (a few minutes)
+#      plus simulate_observed_flux looped over time points. The 40k-wavelength
+#      / 150-time general sweep typically finishes in <30 min on V100; the
+#      80-time eclipse sweep is a few minutes once the JIT cache is warm.
+#      04:00:00 is comfortable; bump it if you crank NUM_WAVELENGTHS or
+#      NUM_TIMES into the hundreds of thousands.
+#============================================================================
+
+#PBS -P mk27                                    
+#PBS -q gpuvolta                                
+#PBS -l ngpus=1
+#PBS -l ncpus=12
+#PBS -l mem=90GB
+#PBS -l walltime=04:00:00
+#PBS -l jobfs=20GB
+#PBS -l storage=scratch/y89+gdata/y89+scratch/mk27   
+#PBS -l wd
+#PBS -N tz_fornacis_lc
+#PBS -j oe
+#PBS -m ae
+#PBS -M maja.jablonska@anu.edu.au
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# 1) Environment
+# ---------------------------------------------------------------------------
+module purge
+module load python3/3.11.7        
+# If your JAX install relies on system CUDA (rather than the pip cuda12 plugin
+# wheels), uncomment and pin to whatever the env was built against:
+# module load cuda/12.6.2 cudnn/9.5.0-cuda12
+
+PYTHON_BIN="${PYTHON_BIN:-/scratch/y89/mj8805/miniforge/envs/astro/bin/python}"
+
+# Let JAX pick up the GPU — SPICE only pins to CPU on macOS, so unsetting
+# JAX_PLATFORMS here is enough. XLA gets its own (non-preallocated) GPU
+# allocation so other things on the node still see free memory.
+unset JAX_PLATFORMS
+export XLA_PYTHON_CLIENT_PREALLOCATE=false
+export XLA_PYTHON_CLIENT_ALLOCATOR=platform
+export TF_CPP_MIN_LOG_LEVEL=2
+
+# Host-side BLAS threads for the small numpy / orbit-grid bits — match the
+# cores PBS gave us.
+export OMP_NUM_THREADS=${PBS_NCPUS:-12}
+export MKL_NUM_THREADS=${PBS_NCPUS:-12}
+export OPENBLAS_NUM_THREADS=${PBS_NCPUS:-12}
+
+# Hugging Face cache for the pretrained intensity emulator. Gadi compute
+# nodes have no internet, so pre-populate this on a login node:
+#   export HF_HOME=/scratch/y89/$USER/hf-cache
+#   python -c "from spice.spectrum.aemu_spectrum_emulator import \
+#       IntensityPretrainedAemuSpectrumEmulator; \
+#       IntensityPretrainedAemuSpectrumEmulator('RozanskiT/TPayne-spice-harps')"
+export HF_HOME="${HF_HOME:-/scratch/y89/$USER/hf-cache}"
+
+# ---------------------------------------------------------------------------
+# 2) Knobs (override with `qsub -v NAME=value,...`)
+# ---------------------------------------------------------------------------
+MODE="${MODE:-both}"                            # general | eclipse | both
+NUM_TIMES="${NUM_TIMES:-150}"
+NUM_ECLIPSE_TIMES="${NUM_ECLIPSE_TIMES:-80}"
+NUM_WAVELENGTHS="${NUM_WAVELENGTHS:-40000}"
+WL_MIN="${WL_MIN:-3000}"
+WL_MAX="${WL_MAX:-10000}"
+ORBIT_CHUNK="${ORBIT_CHUNK:-15}"
+MODEL="${MODEL:-RozanskiT/TPayne-spice-harps}"
+FORCE="${FORCE:-0}"
+
+# Output directory — sits next to the existing data/ dir in tz_fornacis_spectra.ipynb.
+PROJECT="$(echo "${PBS_O_WORKDIR}" | awk -F/ '{for(i=1;i<=NF;i++) if($i=="scratch"){print $(i+1); exit}}')"
+PROJECT="${PROJECT:-y89}"
+OUTPUT_DIR="${OUTPUT_DIR:-/scratch/${PROJECT}/${USER}/tz_fornacis_lightcurves}"
+mkdir -p "${OUTPUT_DIR}"
+
+ARGS=(
+    --mode               "$MODE"
+    --num-times          "$NUM_TIMES"
+    --num-eclipse-times  "$NUM_ECLIPSE_TIMES"
+    --num-wavelengths    "$NUM_WAVELENGTHS"
+    --wl-min             "$WL_MIN"
+    --wl-max             "$WL_MAX"
+    --orbit-chunk        "$ORBIT_CHUNK"
+    --output-dir         "$OUTPUT_DIR"
+    --model              "$MODEL"
+)
+[ "$FORCE" = "1" ] && ARGS+=( --force )
+
+SPICE_REPO="$(cd "${PBS_O_WORKDIR}" && pwd)"
+SCRIPT="${SPICE_REPO}/tutorial/paper_results/tz_fornacis/tz_fornacis_lightcurves.py"
+
+echo "==============================================================="
+echo "Job:        ${PBS_JOBID:-<interactive>}"
+echo "Node:       $(hostname)"
+echo "CPUs/GPUs:  ${PBS_NCPUS:-?} / ${PBS_NGPUS:-?}"
+echo "Python:     ${PYTHON_BIN}"
+echo "HF_HOME:    ${HF_HOME}"
+echo "Mode:       ${MODE}"
+echo "Output:     ${OUTPUT_DIR}"
+echo "Args:       ${ARGS[*]}"
+echo "==============================================================="
+nvidia-smi || true
+"${PYTHON_BIN}" -c "import jax; print('jax', jax.__version__, '| devices:', jax.devices())" || true
+
+# ---------------------------------------------------------------------------
+# 3) Run
+# ---------------------------------------------------------------------------
+cd "${PBS_O_WORKDIR}"
+
+if "${PYTHON_BIN}" -u "${SCRIPT}" "${ARGS[@]}"; then
+    echo "[$(date '+%F %T')] done — outputs in ${OUTPUT_DIR}"
+else
+    rc=$?
+    echo "ABORTED (rc=${rc}). Partial outputs preserved in ${OUTPUT_DIR}." >&2
+    echo "Resubmit after the fix — finished per-mode pickles will be skipped." >&2
+    exit "${rc}"
+fi

--- a/tutorial/paper_results/tz_fornacis/tz_fornacis_lightcurves.py
+++ b/tutorial/paper_results/tz_fornacis/tz_fornacis_lightcurves.py
@@ -1,0 +1,282 @@
+"""Generate TZ Fornacis synthetic lightcurves on GPU.
+
+Runs two synthesis sweeps from the same binary configuration and pretrained
+intensity emulator and writes one pickle per sweep:
+
+* ``general``: ``num_times`` samples uniformly spaced across the full orbital
+  period — the standard out-of-eclipse lightcurve.
+* ``eclipse``: ``num_eclipse_times`` samples split evenly between the primary
+  and secondary eclipse windows predicted by
+  :func:`spice.models.orbit_utils.eclipse_timestamps_kepler` (same Keplerian
+  convention and line-of-sight ``[0, 0, -1]`` as ``check_phoebe_eclipses.py``).
+
+GPU
+---
+The script does not pin a JAX platform; on a Linux GPU node with ``jax[cuda]``
+installed JAX auto-selects the local CUDA device, and on macOS / CPU-only nodes
+SPICE's ``__init__`` keeps it on CPU (slower but still works). The PBS wrapper
+``tz_fornacis_lightcurves.pbs`` sets ``XLA_PYTHON_CLIENT_PREALLOCATE=false`` /
+``XLA_PYTHON_CLIENT_ALLOCATOR=platform`` and unsets ``JAX_PLATFORMS`` so the
+process can use the full GPU device. Print ``jax.devices()`` at startup so the
+log shows whether the GPU was actually picked up.
+
+Resumability
+------------
+Each per-mode pickle is written only if missing, so resubmitting after a
+walltime hit reuses the already-finished sweep.
+
+Usage
+-----
+::
+
+    # both sweeps (default)
+    python tz_fornacis_lightcurves.py --output-dir data
+
+    # eclipse-only, higher resolution
+    python tz_fornacis_lightcurves.py --mode eclipse \\
+        --num-eclipse-times 200 --num-wavelengths 100000
+
+The pickle filenames match the convention already used by
+``tz_fornacis_lightcurve_plot.ipynb`` (``tz_fornacis_data_<mode>_<NW>.pkl``).
+"""
+import os
+import pickle
+import time
+from pathlib import Path
+
+# JAX env vars are best set BEFORE importing jax; this is a no-op when the PBS
+# wrapper already exported them.
+os.environ.setdefault("XLA_PYTHON_CLIENT_PREALLOCATE", "false")
+os.environ.setdefault("XLA_PYTHON_CLIENT_ALLOCATOR", "platform")
+
+import click
+import jax
+jax.config.update("jax_enable_x64", True)
+import jax.numpy as jnp
+import numpy as np
+import astropy.units as u
+from tqdm import tqdm
+
+
+# TZ Fornacis literature parameters used throughout the notebook
+# (tz_fornacis_spectra.ipynb). Kept in one place so the eclipse-time
+# computation and the binary model can't drift apart.
+PRIMARY_MASS = 2.057       # Msun
+PRIMARY_RADIUS = 8.28      # Rsun
+PRIMARY_TEFF = 4930        # K
+PRIMARY_LOGG = 2.91        # cgs
+SECONDARY_MASS = 1.958     # Msun
+SECONDARY_RADIUS = 3.94    # Rsun
+SECONDARY_TEFF = 6650      # K
+SECONDARY_LOGG = 3.35      # cgs
+PERIOD_DAYS = 75.6
+ECC = 0.0
+INCL_DEG = 85.68
+PER0_DEG = 65.99           # argument of periastron
+LONG_AN_DEG = 269.0        # longitude of ascending node
+N_MESH = 500               # icosphere subdivisions per body
+
+
+def _build_binary_and_eclipses(em):
+    """Build the TZ For binary and predict (primary, secondary) eclipse windows.
+
+    Returns
+    -------
+    binary : Binary
+    period_yr : float
+    primary_window_yr : (float, float)   # t1, t4 in years
+    secondary_window_yr : (float, float)
+    """
+    from spice.models.binary import Binary, add_orbit
+    from spice.models.mesh_model import IcosphereModel
+    from spice.models.orbit_utils import eclipse_timestamps_kepler
+
+    period_yr = (PERIOD_DAYS * u.d).to(u.year).value
+    incl_rad = jnp.deg2rad(INCL_DEG)
+    per0_rad = jnp.deg2rad(PER0_DEG)
+    long_an_rad = jnp.deg2rad(LONG_AN_DEG)
+
+    body1 = IcosphereModel.construct(
+        N_MESH, PRIMARY_RADIUS, PRIMARY_MASS,
+        em.to_parameters(dict(teff=PRIMARY_TEFF, logg=PRIMARY_LOGG)),
+        em.stellar_parameter_names,
+        override_log_g=False,
+    )
+    body2 = IcosphereModel.construct(
+        N_MESH, SECONDARY_RADIUS, SECONDARY_MASS,
+        em.to_parameters(dict(teff=SECONDARY_TEFF, logg=SECONDARY_LOGG)),
+        em.stellar_parameter_names,
+        override_log_g=False,
+    )
+    binary = Binary.from_bodies(body1, body2)
+    # add_orbit signature (positional):
+    #   P, ecc, T(=Tperi), i, omega, Omega, mean_anomaly, reference_time,
+    #   vgamma, orbit_resolution_points
+    binary = add_orbit(
+        binary, period_yr, ECC, 0.,
+        incl_rad, per0_rad, long_an_rad,
+        0., 0., 0., 15,
+    )
+
+    (_, t1_p, _, _, t4_p,
+     _, t1_s, _, _, t4_s) = eclipse_timestamps_kepler(
+        PRIMARY_MASS, SECONDARY_MASS,
+        period_yr, ECC, 0.,
+        incl_rad, per0_rad, long_an_rad,
+        PRIMARY_RADIUS, SECONDARY_RADIUS,
+        pad=1.1,
+        los_vector=jnp.array([0., 0., -1.]),
+    )
+    primary_window = (float(t1_p), float(t4_p))
+    secondary_window = (float(t1_s), float(t4_s))
+    if not (np.all(np.isfinite(primary_window)) and np.all(np.isfinite(secondary_window))):
+        raise RuntimeError(
+            "eclipse_timestamps_kepler returned NaN: impact parameter exceeds "
+            "(R1+R2)*pad at the requested geometry — no eclipse to sample."
+        )
+    return binary, period_yr, primary_window, secondary_window
+
+
+def _evaluate_orbit_chunked(binary, times, chunk_size):
+    """Evaluate the orbit in fixed-size chunks (re-uses one JIT specialisation).
+
+    The orbit eval JIT specialises on the input array shape; passing a single
+    flat ``times`` array re-compiles every time ``len(times)`` changes. The
+    notebook chunks via ``times.reshape((10, n//10))`` for the same reason. We
+    keep that pattern but make the chunk size explicit so eclipse runs (with
+    far fewer points) don't pay a recompile per call.
+    """
+    from spice.models.binary import evaluate_orbit_at_times
+
+    times = jnp.asarray(times)
+    n = times.shape[0]
+    pb1, pb2 = [], []
+    for i in tqdm(range(0, n, chunk_size), desc="orbit"):
+        chunk = times[i:i + chunk_size]
+        r1, r2 = evaluate_orbit_at_times(binary, chunk)
+        pb1.extend(list(r1))
+        pb2.extend(list(r2))
+    return pb1, pb2
+
+
+def _synthesize_spectra(em, vws, pb1, pb2):
+    """Run simulate_observed_flux per time-point for each body."""
+    from spice.spectrum import simulate_observed_flux
+
+    log_vws = jnp.log10(vws)
+    spectra_body1 = [simulate_observed_flux(em.intensity, _pb, log_vws) for _pb in tqdm(pb1, desc="primary")]
+    spectra_body2 = [simulate_observed_flux(em.intensity, _pb, log_vws) for _pb in tqdm(pb2, desc="secondary")]
+    return np.asarray(spectra_body1), np.asarray(spectra_body2)
+
+
+def _build_sample_times(mode, period_yr, primary_window, secondary_window,
+                       num_times, num_eclipse_times):
+    """Return list of (label, times_array) sweeps to run for ``mode``."""
+    runs = []
+    if mode in ("general", "both"):
+        times_general = jnp.linspace(0., period_yr, num_times)
+        runs.append(("general", times_general))
+    if mode in ("eclipse", "both"):
+        half = num_eclipse_times // 2
+        t_primary = jnp.linspace(primary_window[0], primary_window[1], half)
+        t_secondary = jnp.linspace(secondary_window[0], secondary_window[1],
+                                   num_eclipse_times - half)
+        runs.append(("eclipses", jnp.concatenate([t_primary, t_secondary])))
+    return runs
+
+
+def _binary_params_dict():
+    """Snapshot of the literature parameters; saved alongside each pickle."""
+    return {
+        "primary_mass": PRIMARY_MASS, "secondary_mass": SECONDARY_MASS,
+        "primary_radius": PRIMARY_RADIUS, "secondary_radius": SECONDARY_RADIUS,
+        "primary_teff": PRIMARY_TEFF, "primary_logg": PRIMARY_LOGG,
+        "secondary_teff": SECONDARY_TEFF, "secondary_logg": SECONDARY_LOGG,
+        "inclination_deg": INCL_DEG, "per0_deg": PER0_DEG,
+        "long_an_deg": LONG_AN_DEG, "ecc": ECC,
+        "period_days": PERIOD_DAYS, "n_mesh": N_MESH,
+    }
+
+
+@click.command()
+@click.option("--mode", type=click.Choice(["general", "eclipse", "both"]),
+              default="both", show_default=True,
+              help="Which sweeps to run. 'both' writes two pickles.")
+@click.option("--num-times", default=150, show_default=True,
+              help="# uniform time samples for the general lightcurve.")
+@click.option("--num-eclipse-times", default=80, show_default=True,
+              help="Total # samples for the eclipse sweep (split evenly between "
+                   "primary and secondary windows).")
+@click.option("--num-wavelengths", default=40000, show_default=True)
+@click.option("--wl-min", default=3000., show_default=True, help="Wavelength min [Angstrom].")
+@click.option("--wl-max", default=10000., show_default=True, help="Wavelength max [Angstrom].")
+@click.option("--orbit-chunk", default=15, show_default=True,
+              help="Times per evaluate_orbit_at_times batch (controls JIT cache reuse).")
+@click.option("--output-dir", default="data", show_default=True)
+@click.option("--model", default="RozanskiT/TPayne-spice-harps", show_default=True,
+              help="Hugging Face repo id or local bundle dir for the intensity emulator.")
+@click.option("--force/--no-force", default=False, show_default=True,
+              help="Overwrite existing per-mode pickles instead of skipping.")
+def main(mode, num_times, num_eclipse_times, num_wavelengths, wl_min, wl_max,
+         orbit_chunk, output_dir, model, force):
+    """Synthesize TZ For general + eclipse lightcurves, writing one pickle per mode."""
+    print(f"[jax] backend={jax.default_backend()}  devices={jax.devices()}")
+
+    from spice.spectrum.aemu_spectrum_emulator import IntensityPretrainedAemuSpectrumEmulator
+    print(f"Loading intensity emulator: {model}")
+    em = IntensityPretrainedAemuSpectrumEmulator(model)
+
+    binary, period_yr, primary_window, secondary_window = _build_binary_and_eclipses(em)
+    yr_to_day = (1 * u.year).to(u.day).value
+    print(f"Period [days]:               {period_yr * yr_to_day:.4f}")
+    print(f"Primary eclipse [days]:      {primary_window[0]*yr_to_day:.4f} -> {primary_window[1]*yr_to_day:.4f}")
+    print(f"Secondary eclipse [days]:    {secondary_window[0]*yr_to_day:.4f} -> {secondary_window[1]*yr_to_day:.4f}")
+
+    vws = jnp.linspace(wl_min, wl_max, num_wavelengths)
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    runs = _build_sample_times(mode, period_yr, primary_window, secondary_window,
+                              num_times, num_eclipse_times)
+
+    for label, times in runs:
+        out_pkl = output_dir / f"tz_fornacis_data_{label}_{num_wavelengths}.pkl"
+        if out_pkl.exists() and not force:
+            print(f"[skip] {out_pkl} already exists (use --force to overwrite)")
+            continue
+
+        print(f"\n=== {label}: {len(times)} time points ===")
+
+        t0 = time.time()
+        pb1, pb2 = _evaluate_orbit_chunked(binary, times, orbit_chunk)
+        print(f"orbit eval: {time.time() - t0:.1f}s")
+
+        t0 = time.time()
+        spectra_body1, spectra_body2 = _synthesize_spectra(em, vws, pb1, pb2)
+        print(f"synthesis:  {time.time() - t0:.1f}s")
+
+        # Write atomically: temp file + rename so a kill mid-write can't leave
+        # a half-pickle that the plot notebook would silently load.
+        tmp_pkl = out_pkl.with_suffix(out_pkl.suffix + ".tmp")
+        with open(tmp_pkl, "wb") as f:
+            pickle.dump({
+                "mode": label,
+                "spectra_body1": spectra_body1,
+                "spectra_body2": spectra_body2,
+                "mesh_body1": pb1,
+                "mesh_body2": pb2,
+                "wavelengths": np.asarray(vws),
+                "times": np.asarray(times),
+                "period_yr": period_yr,
+                "primary_eclipse_window_yr": primary_window,
+                "secondary_eclipse_window_yr": secondary_window,
+                "binary_params": _binary_params_dict(),
+                "model": model,
+            }, f)
+        os.replace(tmp_pkl, out_pkl)
+        print(f"\u2713 saved {out_pkl}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tutorial/paper_results/tz_fornacis_spectra.ipynb
+++ b/tutorial/paper_results/tz_fornacis_spectra.ipynb
@@ -1,443 +1,615 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "63b786be",
-   "metadata": {},
-   "source": [
-    "# TZ Fornacis synthetic spectra\n",
-    "\n",
-    "Generate synthetic spectra for the TZ Fornacis binary system: a G-type giant primary and an F-type subgiant secondary. The spectra are simulated with an `astro_emulators_toolkit` pretrained intensity emulator over one orbital period and saved to a pickle file for downstream analysis.\n",
-    "\n",
-    "This notebook is the interactive counterpart of `tz_fornacis_spectra.py`, updated for the current SPICE API (`spice.spectrum.aemu_spectrum_emulator`)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "0a1b2c3d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import jax\n",
-    "jax.config.update(\"jax_enable_x64\", True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "id": "293d44e2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import matplotlib\n",
-    "%matplotlib inline"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "1759bc6e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from spice.models.binary import Binary, add_orbit, evaluate_orbit_at_times\n",
-    "from spice.models.mesh_model import IcosphereModel\n",
-    "from spice.models.mesh_view import get_mesh_view\n",
-    "from spice.spectrum import simulate_observed_flux\n",
-    "from spice.spectrum.aemu_spectrum_emulator import IntensityPretrainedAemuSpectrumEmulator\n",
-    "import matplotlib.pyplot as plt\n",
-    "import numpy as np\n",
-    "import astropy.units as u\n",
-    "import jax.numpy as jnp\n",
-    "import pickle\n",
-    "import os\n",
-    "from tqdm import tqdm"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "14bb8ca9",
-   "metadata": {},
-   "source": [
-    "## Parameters\n",
-    "\n",
-    "These were command-line options in the script. Edit them here instead."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "2cd11dcb",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "num_times = 150          # Number of time points to sample\n",
-    "num_wavelengths = 40000  # Number of wavelength points\n",
-    "output_dir = 'data'      # Directory to save output files"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "eeeb8988",
-   "metadata": {},
-   "source": [
-    "## Load the pretrained intensity emulator"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "90a6aebc",
-   "metadata": {},
-   "outputs": [
+  "cells": [
     {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6f298dda48254df6b945ab44851ebec8",
-       "version_major": 2,
-       "version_minor": 0
+      "cell_type": "markdown",
+      "id": "63b786be",
+      "metadata": {},
+      "source": [
+        "# TZ Fornacis synthetic spectra\n",
+        "\n",
+        "Generate synthetic spectra for the TZ Fornacis binary system: a G-type giant primary and an F-type subgiant secondary. The spectra are simulated with an `astro_emulators_toolkit` pretrained intensity emulator over one orbital period and saved to a pickle file for downstream analysis.\n",
+        "\n",
+        "This notebook is the interactive counterpart of `tz_fornacis_spectra.py`, updated for the current SPICE API (`spice.spectrum.aemu_spectrum_emulator`)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "0a1b2c3d",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import jax\n",
+        "jax.config.update(\"jax_enable_x64\", True)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "293d44e2",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import matplotlib\n",
+        "%matplotlib inline"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "1759bc6e",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from spice.models.binary import Binary, add_orbit, evaluate_orbit_at_times\n",
+        "from spice.models.mesh_model import IcosphereModel\n",
+        "from spice.models.mesh_view import get_mesh_view\n",
+        "from spice.models.orbit_utils import eclipse_timestamps_kepler\n",
+        "from spice.spectrum import simulate_observed_flux\n",
+        "from spice.spectrum.aemu_spectrum_emulator import IntensityPretrainedAemuSpectrumEmulator\n",
+        "import matplotlib.pyplot as plt\n",
+        "import numpy as np\n",
+        "import astropy.units as u\n",
+        "import jax.numpy as jnp\n",
+        "import pickle\n",
+        "import os\n",
+        "from tqdm import tqdm"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "14bb8ca9",
+      "metadata": {},
+      "source": [
+        "## Parameters\n",
+        "\n",
+        "These were command-line options in the script. Edit them here instead."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "2cd11dcb",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "num_times = 150          # Number of time points to sample\n",
+        "num_wavelengths = 40000  # Number of wavelength points\n",
+        "output_dir = 'data'      # Directory to save output files"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "eeeb8988",
+      "metadata": {},
+      "source": [
+        "## Load the pretrained intensity emulator"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "90a6aebc",
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "d38c7f8729ee4c3c985dc8be6122433b",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "Downloading (incomplete total...): 0.00B [00:00, ?B/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "bd86c0d9f36c4ad7afc48aac7a3b8424",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "Fetching 21 files:   0%|          | 0/21 [00:00<?, ?it/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "E0514 19:28:57.123114  241666 numa_hwloc.cc:121] Call to hwloc_set_cpubind() failed: Invalid argument [22]\n",
+            "E0514 19:28:57.123317  241667 numa_hwloc.cc:121] Call to hwloc_set_cpubind() failed: Invalid argument [22]\n",
+            "E0514 19:28:57.123449  241668 numa_hwloc.cc:121] Call to hwloc_set_cpubind() failed: Invalid argument [22]\n"
+          ]
+        }
+      ],
+      "source": [
+        "em = IntensityPretrainedAemuSpectrumEmulator('RozanskiT/TPayne-spice-harps')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "8bea0e52",
+      "metadata": {},
+      "source": [
+        "## Build the stellar models\n",
+        "\n",
+        "Primary: G-type giant. Secondary: F-type subgiant. `override_log_g=False` keeps the literature surface gravities rather than recomputing log g from the mesh geometry."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "f68809fb",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "/scratch/y89/mj8805/miniforge/envs/astro/lib/python3.11/site-packages/spice/spectrum/aemu_spectrum_emulator.py:57: UserWarning: Possible exceeding parameter bonds - extrapolating.\n",
+            "  warnings.warn(\"Possible exceeding parameter bonds - extrapolating.\")\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[spice] IcosphereModel constructed in 3.5 s\n"
+          ]
+        }
+      ],
+      "source": [
+        "body1 = IcosphereModel.construct(\n",
+        "    500, 8.28, 2.057,\n",
+        "    em.to_parameters(dict(teff=4930, logg=2.91)),\n",
+        "    em.stellar_parameter_names,\n",
+        "    override_log_g=False,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "8f341871",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[spice] IcosphereModel constructed in 0.0 s\n"
+          ]
+        }
+      ],
+      "source": [
+        "body2 = IcosphereModel.construct(\n",
+        "    500, 3.94, 1.958,\n",
+        "    em.to_parameters(dict(teff=6650, logg=3.35)),\n",
+        "    em.stellar_parameter_names,\n",
+        "    override_log_g=False,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "5f5d2d4a",
+      "metadata": {},
+      "source": [
+        "## Set up the binary system with orbital parameters"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "2011eef3",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "binary = Binary.from_bodies(body1, body2)\n",
+        "binary = add_orbit(binary, (75.6*u.d).to(u.year).value, 0., 0., jnp.deg2rad(85.68), jnp.deg2rad(65.99), jnp.deg2rad(269.), 0., 0., 0., 15)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "25934979",
+      "metadata": {},
+      "source": [
+        "## Compute eclipse times\n",
+        "\n",
+        "Use `eclipse_timestamps_kepler` to predict the first/last contact times of the primary and secondary eclipses from the same Keplerian elements passed to `add_orbit`. The line-of-sight convention `[0, 0, -1]` matches the rest of the SPICE pipeline (and `check_phoebe_eclipses.py`)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "3035c24a",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "period_yr = (75.6 * u.d).to(u.year).value\n",
+        "yr_to_day = (1 * u.year).to(u.day).value\n",
+        "\n",
+        "(_, t1_p, _, _, t4_p,\n",
+        " _, t1_s, _, _, t4_s) = eclipse_timestamps_kepler(\n",
+        "    2.057, 1.958,\n",
+        "    period_yr, 0., 0.,\n",
+        "    jnp.deg2rad(85.68),\n",
+        "    jnp.deg2rad(65.99),\n",
+        "    jnp.deg2rad(269.),\n",
+        "    8.28, 3.94,\n",
+        "    pad=1.1,\n",
+        "    los_vector=jnp.array([0., 0., -1.]),\n",
+        ")\n",
+        "\n",
+        "primary_eclipse_window_yr = (float(t1_p), float(t4_p))\n",
+        "secondary_eclipse_window_yr = (float(t1_s), float(t4_s))\n",
+        "\n",
+        "print(f\"Primary eclipse window   [days]: {t1_p * yr_to_day:.3f} -> {t4_p * yr_to_day:.3f}\")\n",
+        "print(f\"Secondary eclipse window [days]: {t1_s * yr_to_day:.3f} -> {t4_s * yr_to_day:.3f}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "cc2a7ead",
+      "metadata": {},
+      "source": [
+        "## Sample time points across the orbital period"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "id": "8b538443",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "times = jnp.linspace(0., (75.6*u.d).to(u.year).value, num_times).reshape((10, num_times//10))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "e4f517e9",
+      "metadata": {},
+      "outputs": [],
+      "source": []
+    },
+    {
+      "cell_type": "markdown",
+      "id": "fe0e8a26",
+      "metadata": {},
+      "source": [
+        "## Evaluate orbital positions at each time point"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "id": "871de9cf",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[spice] Binary orbit evaluated in 19.1 s                                                                                                                    \n",
+            "[spice] Binary orbit evaluated in 0.4 s                                                                                                                     \n",
+            "[spice] Binary orbit evaluated in 0.4 s                                                                                                                     \n",
+            "[spice] Binary orbit evaluated in 0.4 s                                                                                                                     \n",
+            "[spice] Binary orbit evaluated in 0.3 s                                                                                                                     \n",
+            "[spice] Binary orbit evaluated in 0.3 s                                                                                                                     \n",
+            "[spice] Binary orbit evaluated in 0.4 s                                                                                                                     \n",
+            "[spice] Binary orbit evaluated in 0.4 s                                                                                                                     \n",
+            "[spice] Binary orbit evaluated in 0.4 s                                                                                                                     \n",
+            "[spice] Binary orbit evaluated in 0.3 s                                                                                                                     \n",
+            "100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:22<00:00,  2.26s/it]\n"
+          ]
+        }
+      ],
+      "source": [
+        "result = [evaluate_orbit_at_times(binary, t) for t in tqdm(times)]\n",
+        "times = times.flatten()\n",
+        "\n",
+        "pb1, pb2 = [], []\n",
+        "for r in result:\n",
+        "    pb1.extend(r[0])\n",
+        "    pb2.extend(r[1])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "fc0fb387",
+      "metadata": {},
+      "source": [
+        "## Wavelength grid"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "id": "67297744",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "vws = jnp.linspace(3000, 10000, num_wavelengths)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "177ad110",
+      "metadata": {},
+      "source": [
+        "## Simulate spectra for the primary star"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 12,
+      "id": "4883450e",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 150/150 [32:57<00:00, 13.19s/it]\n"
+          ]
+        }
+      ],
+      "source": [
+        "spectra_body1 = [simulate_observed_flux(em.intensity, _pb, jnp.log10(vws)) for _pb in tqdm(pb1)]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "95e0d757",
+      "metadata": {},
+      "source": [
+        "## Simulate spectra for the secondary star"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 13,
+      "id": "c9d5d4f1",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 150/150 [33:37<00:00, 13.45s/it]\n"
+          ]
+        }
+      ],
+      "source": [
+        "spectra_body2 = [simulate_observed_flux(em.intensity, _pb, jnp.log10(vws)) for _pb in tqdm(pb2)]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 14,
+      "id": "90c8dfc1",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "spectra_body1 = np.array(spectra_body1)\n",
+        "spectra_body2 = np.array(spectra_body2)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 15,
+      "id": "08110155",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "plt.plot(vws, spectra_body1[0, :, 0]/spectra_body1[0, :, 1]+spectra_body2[0, :, 0]/spectra_body2[0, :, 1])\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 16,
+      "id": "f3376e8a",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from spice.spectrum import AB_passband_luminosity\n",
+        "from spice.spectrum.filter import GaiaG, GaiaRP, GaiaBP\n",
+        "gaia_g = GaiaG()\n",
+        "gaia_g_mag = [AB_passband_luminosity(gaia_g, vws, s1[:, 0]+s2[:, 0]) for s1, s2 in zip(spectra_body1, spectra_body2)]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 20,
+      "id": "886b4b69",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import matplotlib\n",
+        "%matplotlib inline"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 24,
+      "id": "f051cfc4",
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjUAAAGdCAYAAADqsoKGAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAASIVJREFUeJzt3QmYVOWV8PHTe0N304DIvmvYREGFsIR1omwKCHFEMwGeMXm+cUwGhZEJDDLx0yQgcRwzIcqjM1+MSRSfLwgOg2Ezsg0uAwHc+NhE2WUgQtPd0N101/ect+stqpeqruqqurdu9f/3WHZ3dXVRt6rurXPPe97zpvl8Pp8AAAB4XLrbDwAAACAeCGoAAEBKIKgBAAApgaAGAACkBIIaAACQEghqAABASiCoAQAAKYGgBgAApIRMaUKqqqrk1KlTUlBQIGlpaW4/HAAAEAHtE3zp0iXp2LGjpKeHzsc0qaBGA5ouXbq4/TAAAEAjHD9+XDp37hzy900qqNEMjX1SWrRo4fbDAQAAESgqKjJJCfs5HkqTCmrskJMGNAQ1AAB4S0OlIxQKAwCAlEBQAwAAUgJBDQAASAkENQAAICUQ1AAAgJRAUAMAAFICQQ0AAEgJBDUAACAlENQAAICUQFADAABSAkENAABICQQ1AAAgJTSpBS3hrLKrlVJ0+aqUlF2V0vJKaZ6dIa3zs6UgJ7PBRcnixefzyeWKSrlSUWUeT15OprTIzYrr/X9ZVCafny+RY+dLzXWTB3SUZtkZcbv/8yXl0rp5tqSnR/acFZddlauVVeZ7/Ztotreqyme25aOTF+Xgl5ekTX6O3NK5pdzUsYXkZsVnm9C06H738cki2XPsK6ny+aRfh0LzfmqVlx3xfZwvLpOTFy5L8+xMKcjNlJbNsyQnM7L344XScvlzSbn0vD5f4uX4n0vl7f1fyvUFuXJj23zp3qZ5xI8n0v3+f4rLxOcTyc5Il5ysdLPtTvH5fObYfa6kTCoqqyQzPU0y0tPNcaiwefyOn4lAUJMk9MPk0pWrcvFyReDy59JyOVt0Rb4suiL/c6nMfFjpbfSruVy5aj6w9Q2XnZkhOZnp5pKtX7MypFXzLLkuL0fa5GdLp1bNpLO5NJe2BTlS2CwrLoFFZZVPzhRdMTv5Mb2cL5VDZy/JwS+LzYej7pS16U7auXUz+VrbfHNASJM0OVdcZi66PRWVPvOh3KGwmdzerZW5ZGWkyxfnS+Tz86VyufyqeezpaWnSpiBbbu5UKL3bFwQOKvpc7jn+lazdd1r+8PFpE3QE63Zdc+nfqdA8HxVXfeagq/RDu1lWhrTOy5ZbOhea2+h1+vvTF66Yg0zR5QopulIhx85flr3Hv5K9xy/IV6UVNe7/528fkv895Sa5o1+7mJ/f371/TB5f87G0b5ErE29uL+P6tTcHdX1eyyurzAFbg54vL16RT04VmWBED/7B9Hme2L+9jO/fXvq0byEZtYIjfQ3f++y8vLn3pKz/+IwUXbla53Ho3/RqVyC3dCqUW7oUyi2dWprnXN9rwfS5OnquxLz+Zy5eNu9bveh96vv1UtlVc5DUg6Z5a/jMf4Gfdbv0u9zM6tfhuvxsczDXR6xvVw1K9T3cqWUzub4gx7xeGkBqwGxfv6yMtLDvbf23yq5WyeXySvN+04D72vdX5Yr/Or2NPjd6++rnIF0yM9LM/Wemp5uvel1De1Glz2fut7isUsoqKs3jzMvJkLzsTLM9esnPyZDCZtnmw1rf6+Eeuz4cvc8q+32VzzxmffwlZZVmfzx14bKcvnDZbIe+T8oqqszX8qsa3FcH+Pp98HX6VZ973R/16dPnvbBZprRslm2e6w4tc83z3rNNfr2vvX18+u/vO35R/nTsK9n9xVfy0YmL5t+p7Ybr88wJwJQBHesEHLpNekzZcficrPvwtLx/9LxUBR1L9LnXYHtIj9ZyU8dCaZatx74M85j0+KJf9Xjxxp9OyjsHzppjytofjJCbOxdKLPQ5emn7Z/KLPx4yJ0rB+4ceL4b2aG2OV/re1cejj6tFsyxp1TzbHKdPfHVZDpy5JIfOFptjfHFZhZSWVZr3ld5e7+fw2WL55NTFOseVHm3yZGzvtvIXfdpK3w4F5j71pOViaYXs+uLP5lhUWeWTgtwsc4zQf1e/5udkyufnSmTP8Qvy4YkL5piX779ev+pJpn6vj0eP4fq8n71UJleDn/Ag+l7o1S5fvta2wBwT9Ps+HVqY+0gGaT67xzYBRUVFUlhYKBcvXpQWLVrE7X43f/qlOSjogcAefPU7/Xq10lcjUNFLkf/rhcvl1deVVpiDvZOvhB4UNODRN7U9qGoQoR/0HVs2M290PfjqwUHf3Loz60FTD5QmePlzqdlBT3xVag4Y4eRlV3/w6AFWL4naHv1QsAd33bnru01DjzWYHmA0MDxXXN7g7fR563Zdnhz+8pKcunjFXD+uXzt57v6BMZ1hPfZ/98nvd5+QeNHnQD+YNMjVg5u+BzXo0/ehpYFxv44tTACkQfW+ExdNwFmbfnj06VBgAgkNsjXYO3XhSr3PvZN0v9MPEA08zFd/8KE0INb3h8sPMSwN0PQQoo+xqp4gJhnocaFfhxbmBEkfl77m+j7SgFaf39quy8uWW7u2kuzMNBN8f+HPalr6nizwH4s0s/vZuRJzzAnWrkWOCST0vdaY99gvv32b3HVLB2ksDUYe/t1uOfI/JebnAZ0LTVChQYiebDZE95f6grtQ9NxDT9xCBRe6L2tgowFIouSbz4F083zrZ5l+ToU6Burz8Y0b25jLbea1Tnfl8zs5QiuPW7j6I3M2Gg/6AaFZFL3oWVu7FrlmZ9boWIcRbIRdHYFnmdtXVFWfZQWfeWnw8JWexReXm8emwcdxfxCiO6B+uOsZlRTF74OyS+vm5nLj9dVncl9rly9t8nJqDJto0KGPR7M4h74slsP/UywZaWlm+/SsXLdNP4z0ZFUPHnqmp2d8qvt1edL9uubmuanyH+j1rEKzExdKK2p88Or93Nmvndx1cwcZ0rO1CSx0x9PMhqbCPzx5wTw39szOPLareiZdZZ6jvcerP8htQKM7tr4W9rWpHpYpNAdqPWuyWSI9I//Xtw/Lv23/TDZ++qX86r8+l++PvbHRz63en5p+WyeT0tCMim67OeCZoCvbnBXq4+nTvsCcLWpAooGk0g8APVPVDMzWg/9jPhQ026WXYPpem3RzB3PWPKhbK8kMyhbYs+8PT1w0Z3r61T7n+n1t+t7UM7guraqzKfrY9HHaAFqf72snAGl1Tgbs+0QzUH822bvqDIJ+oGvwdVLfxxcuy1cl5dVDixosBwWyejt9f1dUVkb03tV9SN8fGngHZ340uNMPFZvZ0g8XzSDqV8026UE+1AdOMJNhMlmZ6vu32SF9bfQs3WZeNSjUx97YwF8frz7utgW5JmjtUJhrnnN9b+YEZTBsNjc4q1Gd5ajOcJlsmc8nJeWVZn/R51yzxZqt1Czg/tNFJvOmmYH6aCCpGdjbNMvatTrTqtnR4OyZ3ucf/9+X8ubeU7L90Lk62UW7PX07tDBZRn1v6rFF6WM7/ufL8t7R8/L+Z382x5Ly4OyT/zior6lmN3cePm/er/UFW5HS99YjK/eYY5Jmvh+/q59MHdjR/3z5zOP/4OifzePRf0v3Wz3R1dfSvq76mPT9doP/+Kj7hR6n9DXT95HNlplMcsdCc/zUE0v9ty9dqZB3j5yXP/6/syZ7dfriFfMetwFNzzZ5Mqh7K7PNenzXf1P/Rr/Xi2Z6b+3aUgZ2aWkyOIGMv/82+r3um/pv6/Os7x2bbQqm96lBnB67dXj64NliOXjmkjk+/OnYBXP5xR8Py1tzRprjkBvI1MTB/3pllznA2wNvcDpdd3D9EGxhA5Vm2Salq+OS9gOy+pItLZpVH4ASzX5g6Di1vpk1Za1vVt1R9AP95IUr5ozW1qHoWa4d2mpfmCtdNXhpVf3m73pdc7PD1B7ScJI9qOgYsP1g0h0yljMFvU/NuOgHp93Boxmu+7+7jsv8339onpvtPxwbdkghnNn/5wMTjDzzlwPk3ts7Syyqz6avmCybDk/oAdMGz5pKjub5sh8sH5+6aM7UTSrbPzSkQbhTNVPBbDZR37P2zFKDD/3eZuia26Eq//uksa9LItgPL/3At0NAGrjaM3bzswZZ/qHXtPTqn/X3dujCCfraa6blw5MXzeO1j0lrZHpen2eOD9E8r7qPHT1fYjI0eizS44x+8GtgFo9teug3u2X9J2fkqXv6y8yh3Rp1H6++f0z+cfVHZn95++9Hm4AkmtdVs/N6rNUTo3hkMPS9rsPheoJoh2LddOKrUhM8asClGa0/PDIy4hrASJGpcdCLswaJl+iHmRmCaNlMUoF+gOqHqbSK733G8hxNGdhRnl5/wJzB/OHjMyYDEkumxmZeYqEfEDq0qJd4PD8a0OolWdjsg0hyFzKGe31aNte6msgLaN2gr333NnnmEg8aDEVTNBwtzbIqrWdqDM16/PPGA+b7R775tagCmsAwdpy3Ud/nyXQM79yqudw3WC9d3H4oTOkGEkHPnL8ztKv5/lf/dbTR96Nnrqp5khThAV5jZyJqMXhj/PKdwyazrVmomcMal+mBc5In9wqkmL8a0s3ULOw5diFk/YGTmRqgKbKtCBpTU6OzOX+143Pz/eN39U2q4UrUj1cISBAd5757QIeYsjVarKmc7FEBpBKtnWpsUPN//uuoKfAd+bU2Zjo1kh9BDZBAD36jh/mqvTbO+Kd6R6PUP4UyWXpAAF7N1AT3lYmUndX6zT5tXSl+R/QIaoAE0inWOvVbp2zqdOxoaBNBnaqsmucw/ATEkqnRWZ/R0tlzKrjFAZIbrxSQYHa2RO1mYg3Rvjm22Voew09Ao+j0/cYWCtveR9pfBt5AUAMkmPYqUtokMRra10Jp1ttOSwXgXE1NhT+o0Yag8AZeKSDBtE2/ira1u3abVXm69hHj+UCj2BOCxgw/2YVh7T6M5EdQAySYPcuLZt0pVeKfzq0dcAE4X1OjXakVU7m9g6AGcGj4qTLK4Se7BpCuyQLAjeGn6n3WzWVgEB2CGiDBbOo66kyNv6aGTA0Qh0LhmDI1BDVeQVADJJidDhp1TY3N1DDzCYjD8FP0fWrsKuwUCnsHQQ2QYHb4yRYdRp2poUcNEHvzvUZM6aZQ2HsIaoAEs2d59qwvUmRqAHdrauw+S6GwdxDUAA7V1EQb1DD7CYhfUKP7n+0QHHVHYQqFPYOgBnBs+KmRfWqY/QQ0Wm72tY+5aLM1TOluAkHNtm3bZPLkydKxY0fTEGzNmjV1brN//36ZMmWKFBYWSkFBgQwdOlSOHTsW9n5XrVol/fr1k5ycHPN19erVdW7z/PPPS48ePSQ3N1duv/122b59e7QPH3AvqIlySjeZGiB22Rnppit3Y3rV2H2WKd0pHNSUlJTIgAEDZPny5fX+/siRIzJixAjp06ePbNmyRfbt2yeLFy82gUgo7777rsyYMUNmzpxpbq9f77vvPnn//fcDt3n99dfl0UcflUWLFsmePXtk5MiRMnHixAaDJSBZZj9FXVNDpgaImZ58B2ZAlUc7/MSUbq+JuquXBhJ6CUWDjkmTJsmyZcsC1/Xs2TPsfT733HNy5513ysKFC83P+nXr1q3m+tdee81c9+yzz8p3v/td+d73vhf4mw0bNsgLL7wgS5YsiXYzAMdkNHb2k7+jcB4dhYGYaFCjhffRDj/ZNgxM6W6iNTVVVVWybt066dWrl4wfP17atm0rQ4YMqXeIqnamZty4cTWu07/fuXOn+b68vFx2795d5zb6s71NfcrKyqSoqKjGBXCabdzV2NlPzampAeIyrTvaoCZQKEzzvaYZ1Jw9e1aKi4tl6dKlMmHCBNm4caNMmzZNpk+fbjIvoZw5c0batWtX4zr9Wa9X586dk8rKyrC3qY9mcLSux166dOkS8zYC0cqwU7qjLBS2q3Tn0XwPcGVRS6Z0e0/cMzVq6tSpMnfuXBk4cKAsWLBA7r77blmxYkXYv629CrHP56tzXSS3CabDWBcvXgxcjh8/3oitAuKVqYl27Sea7wHx0KwRSyXo58u14SeWSfCKuK6U16ZNG8nMzDSzl4L17dtXduzYEfLv2rdvXyfjolkfm5nR+83IyAh7m/roTCq9AMlRU9PIQmEyNUBMrhUKRx7UBK/VRk1NE83UZGdny+DBg+XAgQM1rj948KB069Yt5N8NGzZMNm3aVOM6HboaPnx44H51Cnft2+jP9jZAsspqZEdhpnQD7tXUBGdWqalJ4UyN1swcPnw48PPRo0dl79690rp1a+natavMnz/fTM8eNWqUjB07VtavXy9r164107utWbNmSadOnQKzlh555BFz+6efftoMXb355puyefPmGtmdefPmmanegwYNMkHQiy++aKZzP/TQQ7E/C4ATmRqmdAOeWdQyeH8lqEnhoGbXrl0mWAkONtTs2bPl5ZdfNoXBWj+jAcucOXOkd+/eprGe9q6xNBhJ95+9Ks22rFy5Uh5//HHT0+aGG24wfWl05pSlgdL58+flySeflNOnT0v//v3lrbfeCpsBApJqmYQopnTreD5TugEXMzVBw08224oUDGrGjBljDrjhPPjgg+YSSnDWxrr33nvNJZyHH37YXAAvsYvhRZOpKbtaJfbmTOkG4pWpiSaoqT4J0URrOoXCnkH4CSRh870S/3Tu4AMygBhnP0VTKGxnPvlPSuANvFqAQ1O67fTQaBrvaUDDujNAfIafGpOpYTq3txDUAA413wueItqQQD1NDlkaIF7N96KpqbH7K0GNtxDUAAmWlR59pqbE36OmOT1qgJjZIdxoghq7v9qaOHgDrxaQYHb4qCKKjsKBbsIsZgnEraYmmuEn1n3yJoIaIMFsoWFjMjX5LGYJxG9KdxSFwna2It2EvYWgBkiwzEYsk3Bt3ae4rmQCNPFC4aqoC4VtoT+8gaAGcKr5XhTDTyX+M8o8hp8AV2pqAoXC1NR4CkENkGA2fR1Npsb2qaFQGHCp+Z7/JITZT95CUAM4lqmJYvjJH9QwpRuIXbPs6Kd025MQ1n3yFoIawLGamuiHn8jUAC4136NQ2JMIaoAEs2Pytu16NIXC1NQALs1+olDYkwhqAIcyNY1qvsfsJyCONTVV0a/9xArdnkJQAzgY1DS0wr1FpgaIf1BTXlkV8clFYO0npnR7CkENkGDBZ3qRFguTqQHi31E4mrqaQKGw/6QE3kBQAyRY8JlepNO6ydQA8ZOTee2jLtIZUHZZE/rUeAtBDeBkUBNhAz5mPwHxk5aWdm2l7giLha8taEmmxksIagAnh58izdTQpwZwtQFfoKMwhcKeQlADOLBKd1palDU19KkBXF0qgUJhbyKoAZxswBfh8FOgpibnWoEjAOcWtbQnIFlkajyFoAZIsvWfyq9WBVLfefSpAeLbgC/i4SemdHsRQQ3gaKbGF3GWRjX3H4gBxGdad6SFwkzp9iaCGsDBGVCVEQw/2XoanYbKdFLAnULhwNpP/mVO4A28WoADMvzDT3ZYKZySwMynzIQ/LqCpsFO6I2++x/CTFxHUAA6wvS4iadFug5rmQV1QAThbU0OhsDcR1AAOTesOLj4Mp9Q//JSXTaYGcGtKN4XC3kRQAzggyz8ufzWaTA3TuYG4FwpfibJQ2O678AZeLcDBTE0kU7rJ1AAJLBS+WhXV2k9234U3ENQASdZ8r8Q/pZuaGiB+cuzwE1O6UxpBDeDglO6I+tSU+WtqmP0EuFZTc21BSz4mvYRXC0iyjsJkaoD4a2ZX6aZQOKUR1ACOTumOYvYTmRog7oXCZUzpTmkENYCjU7rpUwO4gbWfmgaCGsABdlw+kuZ7Zf7ZGTmZNN8D4h7URFkozOwnbyGoAZKs+Z4NfOyMKQDxLBSObEq3nalIobC3ENQADhYKR5KpsbfhDBFIQPO9aBe05OTCUwhqAAfYA2MFQQ3gilz/cG7kC1oypduLCGoAB/vUVEYw/GTT3mRqgPhpls2U7qaAoAZwtKNwJMNP1V8JagAXC4UDw098THoJrxbggMwoFrS0vWwIaoD4Fwrr7MKqCPbDq/6zC9tjCt5AUAM4mamJZPaT/3ibkcbBFIh3oXBw24RwbE8pTi5SPKjZtm2bTJ48WTp27ChpaWmyZs2aOrfZv3+/TJkyRQoLC6WgoECGDh0qx44dC3u/q1atkn79+klOTo75unr16hq/f+KJJ8y/F3xp3759tA8fcLWmJpLmezZTY/8GQPwKhSNdKoG1n5pIUFNSUiIDBgyQ5cuX1/v7I0eOyIgRI6RPnz6yZcsW2bdvnyxevFhyc3ND3ue7774rM2bMkJkzZ5rb69f77rtP3n///Rq3u+mmm+T06dOBy0cffRTtwwdcwZRuwF3p6WmSnRl5sbAt2Ofkwlsyo/2DiRMnmksoixYtkkmTJsmyZcsC1/Xs2TPsfT733HNy5513ysKFC83P+nXr1q3m+tdee+3ag83MJDsDT7o2pTvy5nsMPwHxr6spv1oVUbGwzapSKNyEa2qqqqpk3bp10qtXLxk/fry0bdtWhgwZUu8QVe1Mzbhx42pcp3+/c+fOGtcdOnTIDHv16NFD7r//fvnss8/C3m9ZWZkUFRXVuABuyAhM6ab5HuB2sXAkvWooFPamuAY1Z8+eleLiYlm6dKlMmDBBNm7cKNOmTZPp06ebzEsoZ86ckXbt2tW4Tn/W6y0Njl555RXZsGGDvPTSS+Z3w4cPl/Pnz4e83yVLlpi6Hnvp0qVLnLYUiE5WejSznyhQBBIhNys94qDGNsq0MxeRosNPDWVq1NSpU2Xu3Lnm+4EDB5qMy4oVK2T06NEh/1YLf4P5fL4a1wUPed18880ybNgwueGGG+TXv/61zJs3r9771GGs4N9ppobABm6w4/J2nD6cSh9BDeD2St02U8MyCU04qGnTpo2pe9HZS8H69u0rO3bsCPl3OospOCtjsz61szfB8vLyTHCjQ1Kh6EwqvQDJM6U7kv4YBDVAIqd1N1RTo31sbFKVoMZb4ppXy87OlsGDB8uBAwdqXH/w4EHp1q1byL/TrMumTZtqXKdDVzq8FK5eRqeOd+jQIQ6PHEie5ntVZGqAhMjxz35qqE9N8H7K8FOKZ2q0Zubw4cOBn48ePSp79+6V1q1bS9euXWX+/PlmevaoUaNk7Nixsn79elm7dq2Z3m3NmjVLOnXqZGpe1COPPGJu//TTT5uhqzfffFM2b95cI7vz2GOPmf44+m9oFufHP/6xGU6aPXt27M8CkETN9+wBldlPQHxlBU4uGgpqrv2ejsIpHtTs2rXLBCuWrVnR4OLll182hcFaP6MBy5w5c6R3796msZ72rrG0EV960HoampFZuXKlPP7446anjdbKvP7666Y42Dpx4oQ88MADcu7cObn++utNQ7/33nsvbAYI8ObaT7ZAkeZ7QCL2w4aaYAb/nindKR7UjBkzxhTxhvPggw+aSyjBWRvr3nvvNZdQNOgBvCrDniFGMaU7nWUSgMQMAzewHwZnVKmp8RbmqgEOyGpMpobVgYH47ocRzkK0+6nuttqJGN5BUAM4wC6KF9GUbntAZe8E4sqeKGhX4XAq7HRuetR4DodNwMECRRuwhEOmBkjsfthQxjSwmCVZGs8hqAEczNTYM8BwaL4HJHj4qYH9MLDuE5kazyGoARw9mEaQqaH5HpAQdkZhQ7Of7DAx07m9h6AGcEBGNGs/+WcXMusCSExNTYOFwqzQ7VkENUCSrf0UmHnBeD7gSsb0WqEwM5+8hqAGSLK1n3TdmeC/ARCn/dBfI9Pw8BP7oFcR1ACOpr0jWNCS5ntAQmRFWLAfGH6iUNhzCGoAB9g0dkNTum2WxvwNmRrA1bWf2Ae9h6AGcHTNmchXB6amBnBp+Mn/exsEwTt4xYAkar4X/HvOEgG3+tRQKOxVBDWAo833GghqghaLtX8DIM4Z0wZOLmzGNIu1SjyHoAZw8AyxsoGxfNt4TxHUAIlapTuyTA37oPcQ1ABONt+LJlOTRqYGcKNPzbXZT+yDXkNQAzjZp6bBtHf1GaLGMxQKA/HeD/2FwpEuaEmhsOcQ1ABJ1FHY/poiYSBx+2HF1QaGn5jS7VkENUASNd+zQU86Q09A3GVH2qeGKd2eRVADOMBmXrRkJty0bjI1gPt9apjS7V0ENYADggsOw50lBjI1TOcGErYfNtxRuDroYfaT9xDUAA4OPzU086LKP/uJmhog/mzfmYZnP1UHPfSp8R6CGsDpTE2YAypniEDi98NIlythSrf3ENQADgjOvIRLfdt6G9LeQAL71DRUsE+hsGcR1AAOSEtLCwQq4Q6ogaCG2U9A4mYhNlQozJRuzyKoARwSSVATGH6ikykQd7aZXnlDw0+BjsJ8RHoNrxjgkCwb1IQ5oFaRqQFcX6U7UCjMyYXnENQATi+mF0mmhindQOL2wQaHn9gPvYqgBnB6/adwU7o5mAIJ3wdtzUwolRQKexZBDZBEjb+uZWrYNYFE1dRQKJy6OHICSTTzopLme0Di9sGgKd0+/75WHwqFvYugBnDhgNpQ2ptlEoD4C+4QHL62jUJhryKoAZye0h1m5gWZGiBxgjsEh+sqbBe8DF7eBN7AKwY4fJYYbpVumu8BCdwHg/rOhFup2554sAab9xDUAA5naux00fqwTAKQOMF9Z8JlTFn7ybsIagCHD6iVrP0EJPVyJRQKexdBDeB0pibc7Cf61ADO9KoJm6nxFwrTBNNzCGqAJOpmSlADuN+rJlAozNpPnkNQAzjdUTii5nvXxv4BON0E018ozNpPnkNQAyRTpsbfECwjjaAGSMh+6J+FGH72k53SzX7oNQQ1gEPsATLslG7/OH8GZ4hAQmT7963wfWrslG4+Ir2GVwxIosX07MkjmRogsRnTSAr2g6eAwxsIagCHCxTDN9+j6RfgSE1NJB2FKRRO/aBm27ZtMnnyZOnYsaOZ879mzZo6t9m/f79MmTJFCgsLpaCgQIYOHSrHjh0LeZ+ffPKJfOtb35Lu3bub+3zuuefqvd3zzz8vPXr0kNzcXLn99ttl+/bt0T58IMmndFd/Ze0nILGdvSNZ+4mamiYQ1JSUlMiAAQNk+fLl9f7+yJEjMmLECOnTp49s2bJF9u3bJ4sXLzaBSCilpaXSs2dPWbp0qbRv377e27z++uvy6KOPyqJFi2TPnj0ycuRImThxYthgCUjGM8Twzfc4mAJO7Idh+9T4TzyCl1WAN2RG+wcaSOglFA06Jk2aJMuWLQtcpwFLOIMHDzYXtWDBgnpv8+yzz8p3v/td+d73vmd+1mzOhg0b5IUXXpAlS5ZEuxmAi02/Gs7UMKUbSNB+GFGfGqZ0e1Vcw9CqqipZt26d9OrVS8aPHy9t27aVIUOG1DtEFY3y8nLZvXu3jBs3rsb1+vPOnTtD/l1ZWZkUFRXVuABuH0wjqakhqAESIyuKflEMPzXxoObs2bNSXFxshpEmTJggGzdulGnTpsn06dNl69atjb7fc+fOSWVlpbRr167G9frzmTNnQv6dZnC0rsdeunTp0ujHAMSt+V6YtHegTw39MYAEDz+Fq6mhUNir4p6pUVOnTpW5c+fKwIEDzXDS3XffLStWrIj5/rWIOJjP56tzXbCFCxfKxYsXA5fjx4/H/BiAxsqMqECR5ntAItk6mfA1Naz91GRqasJp06aNZGZmSr9+/Wpc37dvX9mxY0dM95uRkVEnK6OZodrZm2A5OTnmAiRXe/bQQU2VDWrojwG4svaT7oN2F2VKdxPP1GRnZ5uC3wMHDtS4/uDBg9KtW7eY7lencG/atKnG9frz8OHDG32/gDvDT2RqgGRtghl8PWs/NYFMjdbMHD58OPDz0aNHZe/evdK6dWvp2rWrzJ8/X2bMmCGjRo2SsWPHyvr162Xt2rVmerc1a9Ys6dSpU2DWkhYCf/rpp4HvT548ae4zPz9fbrzxRnP9vHnzZObMmTJo0CAZNmyYvPjii2Y690MPPRSP5wFIigUtbaaGAkXAnUxN8PW2pw1SOKjZtWuXCVYsDTbU7Nmz5eWXXzaFwVo/owHLnDlzpHfv3rJq1SrTu8bSYCQ96M1y6tQpufXWWwM/P/PMM+YyevToQDCkgdL58+flySeflNOnT0v//v3lrbfeiikDBCRbe3Y7NEXzPcCdPjXBQQ0F+00gqBkzZowp0A3nwQcfNJdQgrM2SjsJN3Sf6uGHHzYXwIvsATJ88z0yNYCbBfvBmVTWfvIecmuAQ+wBMlxNjQ1qyNQAid4PQ2RqbLF+elrY2bVITgQ1gEMyIpjSTaYGcGb4qTzEyUWgmzC9ojyJoAZw+gwx3PCTfxg2nTNEIMGFwuFralj3yZsIagCnx/Ij6WTKWSKQ2KCmgZoapnN7E0EN4PiU7kia77FrAoncD0PNfrKzE+1JCLyFVw1Ioo7CLJMAJHo/jKxPDdlSbyKoARye0h1uQUua7wHurtLN8JO3EdQASTKWH/w7pnQD7jTBtPsghcLeRFADJFOmxj/7idQ34E6fGqZ0extBDeDwwdT2ogk3nk+mBkjUfthApsbW1FCs70kENYDDzffCrf1k+9SQqQFcWvvJX2vDEgneRFADOFygGC5TE1gmgeZ7QIL2w/C1bfakg8UsvYmgBnCIPUhWhOkoTPM9wN1MjT2xsMEPvIVXDUiS/hg1mu/RURhwZT8MFAr7gx94C0EN4BBbJxO2UJigBnC3Tw2Fwp5GUAMkSdpbkakB3O5T4y8UJlvqSQQ1gEPsWjLhMzXVB1SGn4BEL1fSwNpPDD95EkENkEyZGn+8w5RuIDGybabmaqg+Nf6aGgqFPYmgBkiqmprqAyrN94DE7oehZiEGZiCSqfEkghrA6bH8MEGNPc6SqQFcWqXbBjVkajyJoAZIouZ7gUwNzfcAV9Z+stfTUdibCGoAh2QEBTU+/3IItdnjLKlvIDFsBiZUxpRCYW8jqAEcErxAXqgW7ZV29hOZGsCdTI1/H2T4yZsIagCHBNfJhBrPt0NTTOkGXKqp8V/P8JM3EdQADgkeUgrVI4OgBkgsG6yUh8jUXFvQko9HL+JVAxwSnM5uaOYFmRogMbJspqaBIWAyNd5EUAM4RAMVWyoT6oBa5S8gJqgBEt8vqr6CfVtATE2NNxHUAC4cUEMupkemBnCsYL++9Z8CHYVpvudJBDWAg+zZX33DT7qYpT1xZPYTkBjBw0r1nVxQKOxtBDWAK5maukFNZVAqnNQ3kKh9MHymhuEnbyOoAdxYIbiemRfBnYYzSH0Dic/U1LMfMvzkbQQ1gIPsNNF6MzXBQQ3N94CESEtLCxTi17cfXq6oNF9zszJ4BTyIoAZwpZtp+OEnZj8Bid8Py6/WzdSUllUHNfk5mbwEHkRQAzjo2hliPcNPQYEOQQ2QOFlhMqbFZVfN1+bZZGq8iKAGSJLGX8GZmqAVFQA4WNtWWl4d1JCp8SaCGsCN2U/1DT8F9ajRcX8ACdoP/ScX9c1+KvYPPzXPZvjJiwhqgGQZfqLxHuCIrDD7IZkabyOoAZJl+MkGNWRpAFcyNdoAs7Tcn6nJoabGiwhqADcyNfW1Zw+sOcPQE+BGTU2pfzq3oqbGmwhqABemktqVgOvL1KQT1AAJlR0iY1rin/mku2BOJh+PXsSrBriQqamvQNEGNWRqAGcyNeW1MjU2qMnLyaRY36MIagAXamqCuwdbZGoAdxeWtfU0ecx8ajpBzbZt22Ty5MnSsWNHE8muWbOmzm32798vU6ZMkcLCQikoKJChQ4fKsWPHQt7nJ598It/61reke/fu5j6fe+65Ord54oknzO+CL+3bt4/24QNJkqkJPfxEpgZwqrN3Vb2N9/IoEm46QU1JSYkMGDBAli9fXu/vjxw5IiNGjJA+ffrIli1bZN++fbJ48WLJzc0NeZ+lpaXSs2dPWbp0adhA5aabbpLTp08HLh999FG0Dx9IjjPEMM336CYMOLMf2hW5a0/n1uEneFPUr9zEiRPNJZRFixbJpEmTZNmyZYHrNGAJZ/DgweaiFixYEPrBZmaSnUFKniEGFw8T1ADuzH6yjffyGH7yrLjW1FRVVcm6deukV69eMn78eGnbtq0MGTKk3iGqxjh06JAZ9urRo4fcf//98tlnn4W9fVlZmRQVFdW4AMnaydQeXwlqAIf6RdWuqWH4yfPiGtScPXtWiouLzTDShAkTZOPGjTJt2jSZPn26bN26Nab71uDolVdekQ0bNshLL70kZ86ckeHDh8v58+dD/s2SJUtMXY+9dOnSJabHACSyk6m9juZ7QGLZurWKqlA1NQw/eVVmvDM1aurUqTJ37lzz/cCBA2Xnzp2yYsUKGT16dKPvO3jI6+abb5Zhw4bJDTfcIL/+9a9l3rx59f7NwoULa/xOMzUENkjWKd32+EqmBkisLH8PmoqrtZrv2W7CDD95VlyDmjZt2pi6l379+tW4vm/fvrJjx454/lOSl5dnghsdkgolJyfHXIBkG36qv6MwNTWAsxnT+pvv5WWzRIJXxXX4KTs72xT8HjhwoMb1Bw8elG7dusXznzL1Mjp1vEOHDnG9X8CRQuF6hp+q/LOfmNINuFPbVsLsp6aXqdGamcOHDwd+Pnr0qOzdu1dat24tXbt2lfnz58uMGTNk1KhRMnbsWFm/fr2sXbvWTO+2Zs2aJZ06dTI1L6q8vFw+/fTTwPcnT54095mfny833nijuf6xxx4z/XH039DanR//+MdmOGn27NnxeB4AZ6eS1pep8V/HMgmAO7MQS+zsJ/rUNJ2gZteuXSZYsWzNigYXL7/8sikM1voZDVjmzJkjvXv3llWrVpneNZY24kv3H9zVqVOn5NZbbw38/Mwzz5iL1uDYYOjEiRPywAMPyLlz5+T66683Df3ee++9uGeAALfXfiJTA7jTpyZ4mQR4U9Sv3JgxY8TnT5OH8uCDD5pLKMFZG6WdhBu6z5UrV0b5SIHk7Y9R75Ru/z6QnsYq3YAT+2GdTI0dfqJQ2LNY+wlwpaNwmEyN/4ALIMF9aupkauzwE5karyKoAVwZyw+zoCWZGsCR/bD2GmzMfvI+ghogSToK27NGamoApwr26+9TQ6bGuwhqAAfZgKXeKd3+oIbme4A7GVNW6fY+ghogCdacMdcR1ACuZkxZpdv7CGoAV2Y/hWu+x24JOJ0xLb9aFQhyWCbBuzh6Ag7KCsx+ovkekEwZU1skrFgmwbsIaoCky9QwpRtwej+0PWpyMtMDw1PwHl45IGkWtGRKN+BWxtT2qMmnR42nEdQArqwOzDIJgFuyMkNnapqz7pOnEdQASdKnJtB8j+EnwPE+Ndca79FN2MsIagA31pypJ1ND8z3AvT41LJGQGghqADfG8uvJ1NB8D3BvlW5W6E4NBDVAksx+ovke4N4q3YHGe9kZvAweRlADuJH2rqdPjZ3SzTIJQKL3w7oZ02L/7Cca73kbQQ3gQtq73ind/usIaoBE74f+jGlV3UxNPrOfPI2gBkiy5nsZaTTfAxK7H9aXqbFTupn95GUENYAbae/6lknwnzWSqQESKzvQWiEoU0PzvZRAUAO4kfauJ1Njr2KZBMCpjGlQpsY236NQ2NMIagCXCxStSn+mhuZ7QKL3w7r9okpt8z2GnzyNoAZIkuZ7ZGoA9wr2S8qrZz/l0VHY0whqAFfas/vE5y8Mrp2poaYGcGGV7kCmhj41XkZQAzgouF7GrvUU+Nn/I0EN4HzBfqnN1DD85GkENYALZ4j1zYAiUwM4e3KhJxY2Y2qndOcx/ORpBDWAC2eI9c2AspkbMjVAgvfDzOD90FerUJjhJy8jqAFcGn6qPQMqENTQfA9wZGFZe3Khi8kGCoUZfvI0WicCDgrOwtQefmJBS8CFYeBKn1yW6oBG5TH85GkENYCD0tLSTI8MTXnXntbN8BPgfMZU138qu1p9gqFX52YxgOFlvHpAkixqSVADOHdyYQMb3Q+De9To7+BdBDVAkixqSVADuLMfXutRw+CF1xHUAEmyqKUNalj7CXBgP7QZUy0SDqzQzcwnryOoAZJkUctKf7+MjKCZGQASvGSJZmr8i1nmk6nxPI6eQJIsanlt+ImXBHBqP9Si/ZKy6poaVuj2Pg6fQJIsanktqGG3BJwLaoJqapjO7XkcPQHXhp9ovgckw8kFjfdSB0ENkHTDT0wpBZw8uWCF7tRBUAO4NZWU5ntAUpxc2ELhPIafPI+gBkiW5nuB2U9kagAnTy5KbaEws588j6AGcJguk2CnkgazQQ5BDeDsyYUdfsqnT43n0T4RcOlgWkHzPcA12f7hp9/vPi67v/jKfN+c4SfPI6gBnN7pQmRq7PBTOmvPAI7thxs++dJ8LWyWJUN6tOaZ9ziCGiDJZj/Zgy2AxPla23zZeeS8DOjSUr799S4yeUBHMjVNsaZm27ZtMnnyZOnYsaNZzXTNmjV1brN//36ZMmWKFBYWSkFBgQwdOlSOHTsW8j5feuklGTlypLRq1cpc7rjjDvnggw/q3O7555+XHj16SG5urtx+++2yffv2aB8+kDxTSUPMfiJTAyTeP02+Sd5b+E158/vfkBmDuxLQNNWgpqSkRAYMGCDLly+v9/dHjhyRESNGSJ8+fWTLli2yb98+Wbx4sQlEQtHbPfDAA/LOO+/Iu+++K127dpVx48bJyZMnA7d5/fXX5dFHH5VFixbJnj17TBA0ceLEsMES4MlMDbOfgITTgvz2haE/l+BNaT6ffyC/MX+cliarV6+We+65J3Dd/fffL1lZWfKb3/ym0Q+qsrLSZGw0cJo1a5a5bsiQIXLbbbfJCy+8ELhd3759zb+9ZMmSiO63qKjIZI8uXrwoLVq0aPTjA2LxyMo98ubeU/L4XX3leyN7Bq7vu3i9XK6olO3/MFa6tG7OkwwAUX5+x3VKd1VVlaxbt0569eol48ePl7Zt25pgpL4hqnBKS0uloqJCWreuLtoqLy+X3bt3m+xNMP15586dIe+nrKzMPBHBFyBpppKGmP3ElG4AaJy4BjVnz56V4uJiWbp0qUyYMEE2btwo06ZNk+nTp8vWrVsjvp8FCxZIp06dTG2NOnfunMnetGvXrsbt9OczZ86EvB/N4GhkZy9dunSJYeuAxPapsbOfGH4CgCSY/aSZGjV16lSZO3eu+X7gwIEmm7JixQoZPXp0g/exbNkyee2110ydTe06HB3uCqYjZ7WvC7Zw4UKZN29e4GfN1BDYIGk6mQbV1Oh7OVAoTE0NALgf1LRp00YyMzOlX79+Na7X2pcdO3Y0+PfPPPOM/PSnP5XNmzfLLbfcUuN+MzIy6mRlNDNUO3sTLCcnx1yA5Bx+upapCR6JIlMDAEkw/JSdnS2DBw+WAwcO1Lj+4MGD0q1bt7B/+7Of/UyeeuopWb9+vQwaNKjO/eoU7k2bNtW4Xn8ePnx4HLcAcHL46VokExzgkKkBAIcyNVozc/jw4cDPR48elb1795qiXp2KPX/+fJkxY4aMGjVKxo4da4KUtWvXmuEkS2c0ac2MnbWkQ0467fvVV1+V7t27BzIy+fn55qJ0GGnmzJkm4Bk2bJi8+OKLZjr3Qw891MhNB9yRYZdJCApqglvWkKkBAIeCml27dplgxbI1K7Nnz5aXX37ZFAZr/YwGLHPmzJHevXvLqlWrTO8aS4ORdP+B3TbV0xlO9957b41/60c/+pE88cQT5nsNlM6fPy9PPvmknD59Wvr37y9vvfVWgxkgIGkzNUGRTI1MDcskAIDzfWq8hj41SAY/33xI/mXzQXng611lyfSbzXUXSstl4JPVw6uHfzJRMv0N+gAA4k6fGgCNW9DSznxS9KkBgMYhqAFcGn4KDmSurftUt3UBACAyBDWAS1O6K4KDGv8oMFkaAGg8ghogCToK2+ndBDUA0HgENYDDbBFwjSndgSUS2CUBoLE4ggIOs31oak7pvlZTAwBoHIIawGFZ/kxNcEfhKn9Qw1RuAGg8ghrAtQUt68vUkKoBgMYiqAFcW9Cy7pRulkgAgMYjqAGSYPaTDWqY/QQAjUdQAyTB7Cf61ABA7AhqAIdl1TP7iUwNAMSOoAZwKVMTPPuJ5nsAEDuCGsCt2U9BmRrbfC+D2U8A0GgENYDDstLrydRQKAwAMSOoAVzrU1O3+R6znwCg8QhqALemdNezTAJBDQA0HkEN4FbzveAp3QQ1ABAzghogCZZJIKgBgNgR1ABuLWgZvEyCf/YTyyQAQOMR1AAOs4GLZmd8/mCm0l9fQ00NADQeQQ3gUvO94BlQdiSKoAYAGo+gBnBp9lPwDKhApobmewDQaAQ1gEuznxSZGgCIH4IawGHBxcBX/eNO1NQAQOwIagCHpaeniY1r7Awomu8BQOwIagAXi4Vtrxr61ABA7AhqABdk+VM1tqswQQ0AxI6gBnAxUxOY/eTvV8PsJwBoPIIawNVFLf2ZGn/Gxi6hAACIHkENkASLWtpMTTp9agCg0QhqgCRY1NLW1LD2EwA0HkENkASLWl4rFGaXBIDG4ggKuMBmZOpO6eblAIDG4hAKuDn7qc6UbnZJAGgsjqCAq7Ofqmp1FOblAIDG4hAKuDr8VB3MVNk+NWRqAKDRCGqAJBh+CmRqmNINAI1GUAMkwfATzfcAIHYENYCLzffs8BPN9wAgdgQ1gJuZGprvAYB7Qc22bdtk8uTJ0rFjR0lLS5M1a9bUuc3+/ftlypQpUlhYKAUFBTJ06FA5duxYyPt86aWXZOTIkdKqVStzueOOO+SDDz6ocZsnnnjC/HvBl/bt20f78IHkytT4a2nKrlaar9mZnGcAQGNFfQQtKSmRAQMGyPLly+v9/ZEjR2TEiBHSp08f2bJli+zbt08WL14subm5Ie9Tb/fAAw/IO++8I++++6507dpVxo0bJydPnqxxu5tuuklOnz4duHz00UfRPnwgqZZJsJmaS1eumq8FuZmuPi4A8LKoj6ATJ040l1AWLVokkyZNkmXLlgWu69mzZ9j7/N3vflcnc/P73/9e3n77bZk1a9a1B5uZSXYGqbVMgr+mxgY1+TkENQDQWHHNdVdVVcm6deukV69eMn78eGnbtq0MGTKk3iGqcEpLS6WiokJat25d4/pDhw6ZYa8ePXrI/fffL5999lnY+ykrK5OioqIaFyCp+tT4Zz9dulJhvhbkZrn6uADAy+Ia1Jw9e1aKi4tl6dKlMmHCBNm4caNMmzZNpk+fLlu3bo34fhYsWCCdOnUytTWWBkevvPKKbNiwwWRyzpw5I8OHD5fz58+HvJ8lS5aYuh576dKlS8zbCCSiTw3DTwAQu8x4Z2rU1KlTZe7cueb7gQMHys6dO2XFihUyevToBu9Dh61ee+01U2cTXIcTPOR18803y7Bhw+SGG26QX//61zJv3rx672vhwoU1fqeZGgIbJOPsJxvUtCBTAwDJEdS0adPG1L3069evxvV9+/aVHTt2NPj3zzzzjPz0pz+VzZs3yy233BL2tnl5eSa40SGpUHJycswFSObZTxrYXK6onv1EoTAAJMnwU3Z2tgwePFgOHDhQ4/qDBw9Kt27dwv7tz372M3nqqadk/fr1MmjQoAb/La2X0anjHTp0iPlxA25maorLqrM0Kp/ZTwDgXKZGa2YOHz4c+Pno0aOyd+9eU9SrU7Hnz58vM2bMkFGjRsnYsWNNkLJ27VoznGTpjCatmdGaFzvkpNO+X331Venevbupl1H5+fnmoh577DHTH0f/Da3d+fGPf2yGk2bPnt34rQdcntKtHYXt0FNuVnpgVhQAIHpRH0F37dolt956q7korVnR7//pn/7J/KyFwVo/o4GKDg/927/9m6xatcr0rrG0EZ/2mbGef/55KS8vl3vvvddkXuxFh6OsEydOmF42vXv3NoXHmhV67733GswAAck8/KRrPxUx8wkA3MnUjBkzRny+6hkboTz44IPmEkpw1kZ9/vnnDf67K1eujOJRAl4ZfrqWqaGeBgBiQ64bcHFKtw4/FQeCGnrUAEAsCGoAF5vv6fDTpTJ/4z26CQNATAhqADeDGoafACBuCGoAV4efqqipAYA4IagBXCwUrqwKLhSmpgYAYkFQA7jcUfjaYpas0A0AsSCoAVxsvqcdhW2mJp9CYQCICUEN4ALbObi6ULg6U8NilgAQG/LdgIuznyp0SveV6maWDD8BQGwIagCXMzWXK+0K3RQKA0AsGH4CXF3QkindABAvBDWAqwta+gILWuYz+wkAYkJQA7jYp0YzNcVlLGgJAPFAUAO42FH44uUKsYveM/sJAGJDUAO4OPtJgxqbucnJZHcEgFhwFAVcnP1kszQ68yktrTrQAQA0DkEN4OLsJ4tuwgAQO4IawAVZ/tlPFo33ACB2BDVAEmRqCGoAIHYENUBSBDV0EwaAWBHUAC5g+AkA4o+gBkiGTE0Oy7ABQKwIagAXp3RbDD8BQOwIagAXm+9ZFAoDQOwIagAXZNQJaigUBoBYEdQALtDuwXZRS0WmBgBiR1ADuCQzqAFffi6FwgAQK4IaIAlmQLUgqAGAmBHUAEkwA4qaGgCIHUENkATFwtTUAEDsCGoAl2TVCGqY/QQAsSKoAVyS6R9+SksTaZ6VwesAADEiqAFcLhTOz8mU9Fp9awAA0SOoAVxe1LIFQ08AEBcENYDLmRqKhAEgPghqAJdraghqACA+CGoAl2c/MfMJAOKDoAZIgkJhAEDsCGoAlzsKM/wEAPFBUAO4JJPhJwCIK4IawCUUCgNAfBHUAC5p2ax6aYR2LXJ5DQDAjaBm27ZtMnnyZOnYsaOkpaXJmjVr6txm//79MmXKFCksLJSCggIZOnSoHDt2LOR9vvHGGzJo0CBp2bKl5OXlycCBA+U3v/lNnds9//zz0qNHD8nNzZXbb79dtm/fHu3DB5LGo3f2kqem3iR339LB7YcCAE0zqCkpKZEBAwbI8uXL6/39kSNHZMSIEdKnTx/ZsmWL7Nu3TxYvXmwCkVBat24tixYtknfffVc+/PBD+eu//mtz2bBhQ+A2r7/+ujz66KPmdnv27JGRI0fKxIkTwwZLQDLr1LKZzBzWXXJZ9wkA4iLN5/P5Gv3HaWmyevVqueeeewLX3X///ZKVlVVvpiUat912m9x1113y1FNPmZ+HDBlirnvhhRcCt+nbt6/5t5csWRLRfRYVFZns0cWLF6VFixYxPT4AAOCMSD+/41pTU1VVJevWrZNevXrJ+PHjpW3btiYYqW+IKhSNsd5++205cOCAjBo1ylxXXl4uu3fvlnHjxtW4rf68c+fOkPdVVlZmnojgCwAASE1xDWrOnj0rxcXFsnTpUpkwYYJs3LhRpk2bJtOnT5etW7eG/VuNvvLz8yU7O9tkaH7xi1/InXfeaX537tw5qayslHbt2tX4G/35zJkzIe9TMzga2dlLly5d4rSlAAAg2WTGO1Ojpk6dKnPnzjXfa9GvZlNWrFgho0ePDvm3WlC8d+9eExRppmbevHnSs2dPGTNmTI3hrtpZndrXBVu4cKG5H0szNQQ2AACkprgGNW3atJHMzEzp169fjeu19mXHjh1h/zY9PV1uvPHGQCCkM6g006JBjd5vRkZGnayMZoZqZ2+C5eTkmAsAAEh9cR1+0qGjwYMHm3qYYAcPHpRu3bpFdV+ahdGaGHu/OoV706ZNNW6jPw8fPjwOjxwAADS5TI0ODx0+fDjw89GjR82wkU7L7tq1q8yfP19mzJhhinzHjh0r69evl7Vr15rp3dasWbOkU6dOgVlL+lX71Nxwww2mKPitt96SV155pcZMJx1GmjlzprndsGHD5MUXXzTTuR966KHYnwUAAND0gppdu3aZYMWyNSuzZ8+Wl19+2RQGa/2MBipz5syR3r17y6pVq0zvGkuDER1uCu598/DDD8uJEyekWbNmpsfNb3/7WxMcWfr9+fPn5cknn5TTp09L//79TfATbQYIAACkppj61HgNfWoAAPAeV/rUAAAAuIWgBgAApASCGgAAkBIIagAAQEqIa/O9ZGdrolkDCgAA77Cf2w3NbWpSQc2lS5fMV5ZKAADAm5/jOgsqlCY1pVvXpjp16pRZZyrcmlHRsmtKHT9+POxUs1TS1La5qW1vU9zmpra9TXGbm9r2ptI2a6iiAU3Hjh1r9Llr0pkafSI6d+6csPvXN4yX3zSN0dS2ualtb1Pc5qa2vU1xm5va9qbKNofL0FgUCgMAgJRAUAMAAFICQU0c5OTkyI9+9CPztaloatvc1La3KW5zU9veprjNTW17m+I2N6lCYQAAkLrI1AAAgJRAUAMAAFICQQ0AAEgJBDUAACAlENTEwfPPPy89evSQ3Nxcuf3222X79u2SCpYsWSKDBw82HZjbtm0r99xzjxw4cKDGbbTO/IknnjBdHps1ayZjxoyRTz75RFJl+7Xz9KOPPprS23vy5En5zne+I9ddd500b95cBg4cKLt3707Jbb569ao8/vjjZn/VbenZs6c8+eSTptt4qmzvtm3bZPLkyebx6/t3zZo1NX4fyfaVlZXJ3/3d30mbNm0kLy9PpkyZIidOnBAvbnNFRYX88Ic/lJtvvtlsi95m1qxZpru8V7e5odc42N/8zd+Y2zz33HOe3d5oENTE6PXXXzcfeosWLZI9e/bIyJEjZeLEiXLs2DHxuq1bt8r3v/99ee+992TTpk3mA2HcuHFSUlISuM2yZcvk2WefleXLl8t///d/S/v27eXOO+8MrLPlVbotL774otxyyy01rk+17f3qq6/kG9/4hmRlZckf/vAH+fTTT+Wf//mfpWXLlim5zU8//bSsWLHCbMv+/fvNtv3sZz+TX/ziFymzvbp/DhgwwDz++kSyfXpMW716taxcuVJ27NghxcXFcvfdd0tlZaV4bZtLS0vlT3/6kyxevNh8feONN+TgwYPmQzyYl7a5odfY0mDn/fffN8FPbV7a3qjolG403te//nXfQw89VOO6Pn36+BYsWJByT+vZs2d1+r9v69at5ueqqipf+/btfUuXLg3c5sqVK77CwkLfihUrfF516dIl39e+9jXfpk2bfKNHj/Y98sgjKbu9P/zhD30jRowI+ftU2+a77rrL9+CDD9a4bvr06b7vfOc7Kbm9ur+uXr068HMk23fhwgVfVlaWb+XKlYHbnDx50peenu5bv369z2vbXJ8PPvjA3O6LL77w/DaH2t4TJ074OnXq5Pv444993bp18/3Lv/xL4Hde3t6GkKmJQXl5uUnTa/YimP68c+dOSTUXL140X1u3bm2+Hj16VM6cOVNj+7XB0+jRoz29/Zqduuuuu+SOO+6ocX0qbu9//Md/yKBBg+Qv//IvzRDjrbfeKi+99FLKbvOIESPk7bffNmfqat++feYsddKkSSm5vbVFsn16TNMhm+Db6Jl+//79U+I5sMcyHZKxGclU2+aqqiqZOXOmzJ8/X2666aY6v0+17W2yC1rG27lz50yqrl27djWu15/1wJFK9IRg3rx55kNB3/jKbmN92//FF1+IF2kqVlPUmpavLRW397PPPpMXXnjBvLb/+I//KB988IHMmTPHfNBp3UGqbbPWVugHWp8+fSQjI8Psvz/5yU/kgQceML9Pte2tLZLt09tkZ2dLq1atUvK4duXKFVmwYIF8+9vfDizwmGrb/PTTT0tmZqbZl+uTatsbjKAmDjTirx0A1L7O637wgx/Ihx9+aM5qU3X7jx8/Lo888ohs3LjRFH2Hkirba8/oNFPz05/+1PysmRotGtVAR4OaVNtmrYH77W9/K6+++qo5g927d6+pLdCz1NmzZ6fc9obSmO1LhedAsxP333+/ed/rBI+GeHGbd+/eLT//+c/NyVm0j92L21sbw08x0KpxPdurHdmePXu2zpmQl2mFvA5TvPPOO9K5c+fA9VpgqFJl+/VgoI9dZ7DpWY5etFj6X//1X833dptSZXtVhw4dpF+/fjWu69u3b6DQPdVeY03H61m6frDpbBhN0c+dO9fMdEvF7a0tku3T2+jQuhaRh7qNVwOa++67zwzB6cQHm6VJtW3evn27edxdu3YNHMc0C/f3f//30r1795Tb3toIamKg6Tv9ANQdJJj+PHz4cPE6jdo1Q6OzBf74xz+aabDB9GfdOYK3X3cUDQS8uP3f/OY35aOPPjJn7/aiWYy/+qu/Mt/r9N9U2l6lM59qT9PXepNu3bql5GusM2HS02se9vTExE7pTrXtrS2S7dNjms6GC77N6dOn5eOPP/bsc2ADmkOHDsnmzZtN+4JgqbTNM2fONFn14OOYZiI1oN+wYUPKbW8dblcqe51Wj2sV+b//+7/7Pv30U9+jjz7qy8vL833++ec+r/vbv/1bMytiy5YtvtOnTwcupaWlgdvoLAq9zRtvvOH76KOPfA888ICvQ4cOvqKiIl8qCJ79lIrbq7NAMjMzfT/5yU98hw4d8v3ud7/zNW/e3Pfb3/42Jbd59uzZZkbIf/7nf/qOHj1qtqlNmza+f/iHf0iZ7dXZe3v27DEXPcQ/++yz5ns70yeS7dMZnZ07d/Zt3rzZ96c//cn3F3/xF74BAwb4rl696vPaNldUVPimTJlitmfv3r01jmVlZWWe3OaGXuPaas9+8tr2RoOgJg5++ctfmjdNdna277bbbgtMefY63Vnqu/zqV7+qMUX0Rz/6kZkmmpOT4xs1apQ5UKaK2kFNKm7v2rVrff379zfbo+0IXnzxxRq/T6Vt1g9ufT27du3qy83N9fXs2dO3aNGiGh9uXt/ed955p979VgO6SLfv8uXLvh/84Ae+1q1b+5o1a+a7++67fceOHfN5cZs1eA11LNO/8+I2N/QaRxLUeGl7o5Gm/3M7WwQAABAramoAAEBKIKgBAAApgaAGAACkBIIaAACQEghqAABASiCoAQAAKYGgBgAApASCGgAAkBIIagAAQEogqAEAACmBoAYAAKQEghoAACCp4P8DQGqdoc9P98YAAAAASUVORK5CYII=",
+            "text/plain": [
+              "<Figure size 640x480 with 1 Axes>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "times_day = np.asarray(times) * yr_to_day\n",
+        "\n",
+        "fig, ax = plt.subplots()\n",
+        "ax.plot(times_day, gaia_g_mag)\n",
+        "ax.axvspan(t1_p * yr_to_day, t4_p * yr_to_day,\n",
+        "           alpha=0.2, color='C1', label='Primary eclipse')\n",
+        "ax.axvspan(t1_s * yr_to_day, t4_s * yr_to_day,\n",
+        "           alpha=0.2, color='C2', label='Secondary eclipse')\n",
+        "ax.set_xlabel('Time [days]')\n",
+        "ax.set_ylabel('Gaia G magnitude')\n",
+        "ax.invert_yaxis()\n",
+        "ax.legend()\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "c35f426f",
+      "metadata": {},
+      "source": [
+        "## Save the spectra and meshes"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 18,
+      "id": "02cfd4f2",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "✓ Spectra data saved to data/tz_fornacis_data_40000.pkl\n"
+          ]
+        }
+      ],
+      "source": [
+        "os.makedirs(output_dir, exist_ok=True)\n",
+        "\n",
+        "with open(f'{output_dir}/tz_fornacis_data_{num_wavelengths}.pkl', 'wb') as f:\n",
+        "    pickle.dump({\n",
+        "        'spectra_body1': spectra_body1,\n",
+        "        'spectra_body2': spectra_body2,\n",
+        "        'mesh_body1': pb1,\n",
+        "        'mesh_body2': pb2,\n",
+        "        'wavelengths': vws,\n",
+        "        'times': times,\n",
+        "        'primary_eclipse_window_yr': primary_eclipse_window_yr,\n",
+        "        'secondary_eclipse_window_yr': secondary_eclipse_window_yr,\n",
+        "    }, f)\n",
+        "\n",
+        "print(f\"\\u2713 Spectra data saved to {output_dir}/tz_fornacis_data_{num_wavelengths}.pkl\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 19,
+      "id": "2471cb88",
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "array([[[1.01994651e-07, 1.03838903e-07],\n",
+              "        [1.01509622e-07, 1.04157683e-07],\n",
+              "        [9.59595650e-08, 1.04337456e-07],\n",
+              "        ...,\n",
+              "        [1.01133078e-07, 1.02973786e-07],\n",
+              "        [1.02055661e-07, 1.03357200e-07],\n",
+              "        [1.00826838e-07, 1.02628183e-07]],\n",
+              "\n",
+              "       [[1.02527549e-07, 1.03965879e-07],\n",
+              "        [1.01258611e-07, 1.03971182e-07],\n",
+              "        [9.65123586e-08, 1.04247182e-07],\n",
+              "        ...,\n",
+              "        [1.01398641e-07, 1.03151791e-07],\n",
+              "        [1.01747997e-07, 1.03282647e-07],\n",
+              "        [1.01210298e-07, 1.02794120e-07]],\n",
+              "\n",
+              "       [[1.02689874e-07, 1.03961596e-07],\n",
+              "        [1.01480989e-07, 1.04133867e-07],\n",
+              "        [9.86791106e-08, 1.04135645e-07],\n",
+              "        ...,\n",
+              "        [1.01687692e-07, 1.03292349e-07],\n",
+              "        [1.01074120e-07, 1.03239875e-07],\n",
+              "        [1.01219831e-07, 1.02838289e-07]],\n",
+              "\n",
+              "       ...,\n",
+              "\n",
+              "       [[9.99236628e-08, 1.03524411e-07],\n",
+              "        [9.95902290e-08, 1.04072567e-07],\n",
+              "        [1.02634073e-07, 1.04115451e-07],\n",
+              "        ...,\n",
+              "        [9.59997585e-08, 1.02663870e-07],\n",
+              "        [1.02322895e-07, 1.03706016e-07],\n",
+              "        [9.56520611e-08, 1.02686407e-07]],\n",
+              "\n",
+              "       [[1.00598458e-07, 1.03445803e-07],\n",
+              "        [1.00484507e-07, 1.04054826e-07],\n",
+              "        [1.03071599e-07, 1.04489802e-07],\n",
+              "        ...,\n",
+              "        [9.94255891e-08, 1.02862273e-07],\n",
+              "        [1.02319050e-07, 1.03629103e-07],\n",
+              "        [9.87179109e-08, 1.02742589e-07]],\n",
+              "\n",
+              "       [[1.01994651e-07, 1.03838903e-07],\n",
+              "        [1.01509622e-07, 1.04157683e-07],\n",
+              "        [9.59595650e-08, 1.04337456e-07],\n",
+              "        ...,\n",
+              "        [1.01133078e-07, 1.02973786e-07],\n",
+              "        [1.02055661e-07, 1.03357200e-07],\n",
+              "        [1.00826838e-07, 1.02628183e-07]]], shape=(150, 40000, 2))"
+            ]
+          },
+          "execution_count": null,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "spectra_body1"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "4487c345",
+      "metadata": {},
+      "outputs": [],
+      "source": []
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "astro",
+      "language": "python",
+      "name": "astro"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
       },
-      "text/plain": [
-       "Downloading (incomplete total...): 0.00B [00:00, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a3b9aa4525a340ec86999c2e566dbd00",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Fetching 21 files:   0%|          | 0/21 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "E0511 19:25:39.417620  136082 cuda_executor.cc:1206] [0] Failed to allocate device memory: INTERNAL: [0] Failed to allocate 29.76GiB (31950225408 bytes) of device memory: : CUDA_ERROR_OUT_OF_MEMORY: out of memory\n",
-      "E0511 19:25:39.418121  136082 cuda_executor.cc:1206] [0] Failed to allocate device memory: INTERNAL: [0] Failed to allocate 26.78GiB (28755202048 bytes) of device memory: : CUDA_ERROR_OUT_OF_MEMORY: out of memory\n",
-      "E0511 19:25:39.418579  136082 cuda_executor.cc:1206] [0] Failed to allocate device memory: INTERNAL: [0] Failed to allocate 24.10GiB (25879681024 bytes) of device memory: : CUDA_ERROR_OUT_OF_MEMORY: out of memory\n",
-      "E0511 19:25:39.419025  136082 cuda_executor.cc:1206] [0] Failed to allocate device memory: INTERNAL: [0] Failed to allocate 21.69GiB (23291711488 bytes) of device memory: : CUDA_ERROR_OUT_OF_MEMORY: out of memory\n",
-      "E0511 19:25:39.419465  136082 cuda_executor.cc:1206] [0] Failed to allocate device memory: INTERNAL: [0] Failed to allocate 19.52GiB (20962539520 bytes) of device memory: : CUDA_ERROR_OUT_OF_MEMORY: out of memory\n",
-      "E0511 19:25:39.419905  136082 cuda_executor.cc:1206] [0] Failed to allocate device memory: INTERNAL: [0] Failed to allocate 17.57GiB (18866284544 bytes) of device memory: : CUDA_ERROR_OUT_OF_MEMORY: out of memory\n",
-      "E0511 19:25:39.420352  136082 cuda_executor.cc:1206] [0] Failed to allocate device memory: INTERNAL: [0] Failed to allocate 15.81GiB (16979655680 bytes) of device memory: : CUDA_ERROR_OUT_OF_MEMORY: out of memory\n",
-      "E0511 19:25:39.420786  136082 cuda_executor.cc:1206] [0] Failed to allocate device memory: INTERNAL: [0] Failed to allocate 14.23GiB (15281689600 bytes) of device memory: : CUDA_ERROR_OUT_OF_MEMORY: out of memory\n",
-      "E0511 19:25:39.421218  136082 cuda_executor.cc:1206] [0] Failed to allocate device memory: INTERNAL: [0] Failed to allocate 12.81GiB (13753520128 bytes) of device memory: : CUDA_ERROR_OUT_OF_MEMORY: out of memory\n",
-      "E0511 19:25:39.421646  136082 cuda_executor.cc:1206] [0] Failed to allocate device memory: INTERNAL: [0] Failed to allocate 11.53GiB (12378167296 bytes) of device memory: : CUDA_ERROR_OUT_OF_MEMORY: out of memory\n",
-      "E0511 19:25:39.422072  136082 cuda_executor.cc:1206] [0] Failed to allocate device memory: INTERNAL: [0] Failed to allocate 10.38GiB (11140349952 bytes) of device memory: : CUDA_ERROR_OUT_OF_MEMORY: out of memory\n",
-      "E0511 19:25:39.422496  136082 cuda_executor.cc:1206] [0] Failed to allocate device memory: INTERNAL: [0] Failed to allocate 9.34GiB (10026314752 bytes) of device memory: : CUDA_ERROR_OUT_OF_MEMORY: out of memory\n"
-     ]
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.15"
     }
-   ],
-   "source": [
-    "em = IntensityPretrainedAemuSpectrumEmulator('RozanskiT/TPayne-spice-harps')"
-   ]
   },
-  {
-   "cell_type": "markdown",
-   "id": "8bea0e52",
-   "metadata": {},
-   "source": [
-    "## Build the stellar models\n",
-    "\n",
-    "Primary: G-type giant. Secondary: F-type subgiant. `override_log_g=False` keeps the literature surface gravities rather than recomputing log g from the mesh geometry."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "f68809fb",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/scratch/y89/mj8805/miniforge/envs/astro/lib/python3.11/site-packages/spice/spectrum/aemu_spectrum_emulator.py:57: UserWarning: Possible exceeding parameter bonds - extrapolating.\n",
-      "  warnings.warn(\"Possible exceeding parameter bonds - extrapolating.\")\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[spice] IcosphereModel constructed in 3.5 s\n"
-     ]
-    }
-   ],
-   "source": [
-    "body1 = IcosphereModel.construct(\n",
-    "    500, 8.28, 2.057,\n",
-    "    em.to_parameters(dict(teff=4930, logg=2.91)),\n",
-    "    em.stellar_parameter_names,\n",
-    "    override_log_g=False,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "8f341871",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[spice] IcosphereModel constructed in 0.0 s\n"
-     ]
-    }
-   ],
-   "source": [
-    "body2 = IcosphereModel.construct(\n",
-    "    500, 3.94, 1.958,\n",
-    "    em.to_parameters(dict(teff=6650, logg=3.35)),\n",
-    "    em.stellar_parameter_names,\n",
-    "    override_log_g=False,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5f5d2d4a",
-   "metadata": {},
-   "source": [
-    "## Set up the binary system with orbital parameters"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "2011eef3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "binary = Binary.from_bodies(body1, body2)\n",
-    "binary = add_orbit(binary, (75.6*u.d).to(u.year).value, 0., 0., jnp.deg2rad(85.68), jnp.deg2rad(65.99), jnp.deg2rad(269.), 0., 0., 0., 15)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cc2a7ead",
-   "metadata": {},
-   "source": [
-    "## Sample time points across the orbital period"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "8b538443",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "times = jnp.linspace(0., (75.6*u.d).to(u.year).value, num_times).reshape((10, num_times//10))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fe0e8a26",
-   "metadata": {},
-   "source": [
-    "## Evaluate orbital positions at each time point"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "871de9cf",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[spice] Binary orbit evaluated in 18.9 s                                                                                                                 \n",
-      "[spice] Binary orbit evaluated in 0.4 s                                                                                                                  \n",
-      "[spice] Binary orbit evaluated in 0.4 s                                                                                                                  \n",
-      "[spice] Binary orbit evaluated in 0.4 s                                                                                                                  \n",
-      "[spice] Binary orbit evaluated in 0.3 s                                                                                                                  \n",
-      "[spice] Binary orbit evaluated in 0.3 s                                                                                                                  \n",
-      "[spice] Binary orbit evaluated in 0.4 s                                                                                                                  \n",
-      "[spice] Binary orbit evaluated in 0.4 s                                                                                                                  \n",
-      "[spice] Binary orbit evaluated in 0.4 s                                                                                                                  \n",
-      "[spice] Binary orbit evaluated in 0.3 s                                                                                                                  \n",
-      "100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:22<00:00,  2.24s/it]\n"
-     ]
-    }
-   ],
-   "source": [
-    "result = [evaluate_orbit_at_times(binary, t) for t in tqdm(times)]\n",
-    "times = times.flatten()\n",
-    "\n",
-    "pb1, pb2 = [], []\n",
-    "for r in result:\n",
-    "    pb1.extend(r[0])\n",
-    "    pb2.extend(r[1])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fc0fb387",
-   "metadata": {},
-   "source": [
-    "## Wavelength grid"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "67297744",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "vws = jnp.linspace(3000, 10000, num_wavelengths)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "177ad110",
-   "metadata": {},
-   "source": [
-    "## Simulate spectra for the primary star"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "4883450e",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:10<00:00,  5.24s/it]\n"
-     ]
-    }
-   ],
-   "source": [
-    "spectra_body1 = [simulate_observed_flux(em.intensity, _pb, jnp.log10(vws)) for _pb in tqdm(pb1[:2])]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "95e0d757",
-   "metadata": {},
-   "source": [
-    "## Simulate spectra for the secondary star"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "c9d5d4f1",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 244.83it/s]\n"
-     ]
-    }
-   ],
-   "source": [
-    "spectra_body2 = [simulate_observed_flux(em.intensity, _pb, jnp.log10(vws)) for _pb in tqdm(pb2[:2])]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "id": "90c8dfc1",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "spectra_body1 = np.array(spectra_body1)\n",
-    "spectra_body2 = np.array(spectra_body2)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "id": "08110155",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiwAAAGdCAYAAAAxCSikAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAASphJREFUeJzt3Ql4U1XaB/A33dK9dF/oShe6UtoC3ShQKYWyCCqC7CDIoKggrggqoCPjfIqAKIrDgIzD4gyrI8iiQkEQBQF3BEGBUkQQWhZbKM33nIMJSZumSZrkbv/f81xCbm5u7j1Jc9+8Z1NpNBoNAQAAAIiYk9AHAAAAANAcBCwAAAAgeghYAAAAQPQQsAAAAIDoIWABAAAA0UPAAgAAAKKHgAUAAABEDwELAAAAiJ4LyUR9fT2dPn2afHx8SKVSCX04AAAAYAY2fu2lS5coIiKCnJyc5B+wsGAlKipK6MMAAAAAK5w8eZIiIyPlH7CwzIr2hH19fYU+HAAAADBDdXU1Tzhor+OyD1i01UAsWEHAAgAAIC3NNedAo1sAAAAQPQQsAAAAIHoIWAAAAED0ELAAAACA6CFgAQAAANFDwAIAAACih4AFAAAARA8BCwAAAIgeAhYAAAAQPQQsAAAAIK+AZfbs2dSxY0c+3n9ISAgNGDCADh8+3OzzduzYQTk5OeTu7k5t2rShN998s9E2q1evptTUVFKr1fx27dq1lp0JAAAAyJZFAQsLPCZOnEifffYZbd26lerq6qi0tJSuXLnS5HOOHz9OvXv3pqKiIjpw4AA9/fTT9PDDD/MARWvPnj00ePBgGjFiBB06dIjfDho0iPbu3duyswMAAABZUGk0Go21T/7tt994poUFMl26dDG6zZNPPkkbNmyg77//XrduwoQJPDBhgQrDghU2W+OmTZt02/Tq1Yv8/f1pxYoVZh0Le76fnx9VVVVh8kOZqa/X0GfHz1PV1etUlhHe5HZXauto4fafKDnch/q2i9CtP3uphjxcnelSTR2F+brTH9dv0MGTF8nFSUXprf3o6rUbFOyjJu2fQnMTcElB3Y16cnFu/HuEnaP2/JraRr/cKy7+QVEBnlRZ9QeF+rjz9dfr66nmWj15qZ2ppq6el62zk0r3nHqNht+/fkNDrs4q3etV/XGdlu89QaVpoRTq606VF/8gtYszubs50eZvzlBGZCvKjLz5fnxy+CzlxPjTxavXydPNmfy93PhzD5+5RN9XVpPaxYl6podR3Q0Nzdn6I3VrG0ztWvvR/I+PUlZ0K93nYUR+LG36upL8Pd1o/y8XaGrvZL4P9r4f++0yjSqI5a/x+5Vr/PgSQ73J09WFjp+/QslhPuTu6myX9wdA+/fY3HcO24ZtplIR1dWzvyknun6jnn9ufdxd+Gf0p98uU4iPmm/vrXahk7//QYdOXaRe6WHkrFLRtRv1/PN9/NwV+rW6hnqmhdGbO36i0tQwCvVVk4+7K9XW3eDPFeL7z9zrd4sClqNHj1JiYiJ9/fXXlJ6ebnQbFshkZWXRvHnzdOtYdQ/LoFy9epVcXV0pOjqaHnnkEb5ovfrqqzR37lz65ZdfjO63traWLw2np7Z1wHLuci09t+FberA4gRJCvPmHhWEXz0u11yncz4OuXKsjJ5WK1h2ooO4pIXzd1Wt1tKj8GG3+9ldqG+pN0/um0onfr1Kwt5q+rqiipFBvSggxnEq7uuY6+bq7WnR87HW2fPsr/5JmFwEhv2D/uHaD3tt3kpdBpL+nWc95Z/fP/KI4tSy50R8KuzCxZcp7h3TrJnSN539YSz79mQZ3iOKBxoJPjpI9vTEsm/YeO0/v7Ln1WeyeHEKf/nSOaq7X06TuifxCV9w2hJe/9uLN3psfzlyi63X1/D67gA9ffCtrWJISStu+/1V3f+mYjvx8/m/zYdp++De+zsvNma5ev0G3Z0bwL6S3dx6367mCaY+VJlF2tD8VJAShqExgF1Ttd6UU6Qf2pr6Xvzp1kQfD7CoaHeipey4LEFgwzvz46yUe1LPA/1pdPX169Bz/Aca8teMYSc3Pf+sjvYCFPa1///504cIF2rlzZ5PbJSUl0ejRo3lVkNbu3bupsLCQTp8+TeHh4eTm5kZLly6loUOH6rZZvnw5jRkzxiAo0TdjxgyaOXNmo/W2Dlhin/qA7On47N78D2PJp8dp5vvf8XVjCmP5BXnePe2pd0Y4ffzDWeoUG8CDpxsaDSWH+dKs97+j7yqr+B/Lpm/O6Pb3/IB0GpEXw78w9h77nQriA/kvXvYa2guprdRcv8H/+PLjA8nTzYXSnv2Qrly7wV/npxd7m/X85Gc+5P9fNT6PR/kp4T66Lwp7l729HHy2B334zRl6as3XQh8K2NEnj3WjuCAvyZYx+w5f8flJKkoM4hdTW/nPvpP0+H+/IjcXJ9rz1G0U4OWm+5u+VHOdZzh91K78Fz/7QcKyY+zxi1ev0b6fL1DXtsE2D3bY9+HJ36/y7N13p6v592iXpGBatudnnjlk35Es86D/g+CdezvRNxVV/AcEwzIRU3ok0ctbfqToAE+esWvO6vvz6a6FN2sSWDaEZXml7uCzPaiVp5u0AhbWluWDDz6gXbt2UWRkpMmAhQUeU6dO1a379NNPqXPnzlRZWUlhYWE8YHnnnXdoyJAhum3+/e9/09ixY6mmpkbQDIsYL5rLx+XS0H803b6nLD3MIIjRivBzp9NVNXT4hV666N9a7I+/6O+f6O6zP2SWmtd6dXAmT9ff3SGKZ0S0r8c+bkt3/0zvfvYL/fRb47ZPS8Z0pNMX/6Bpa79p0fEBOPLX5s/nrtA/dh2jPhkR1C7Sj1djsYswC8rZRS8r2r/RD4Zfzl/hF2hWRcYyjSxNnxhqmHXVZi5Zyj8twtem6fqhb39Gu3+6+Ut/Rr9UGl0YxzMAe46dp63fnaFpvVPJw82y7wlWDZf23GaDdaPyY2hm/3R+vl3/b7suc8h+3DCvD82mnUd+o5VfnOT3E0O8eUDw4p0ZPGvcnN8u1VLHv27j///7wHY0qEMUffBVJU1c/iV/bf3MKLTcA93i6YleySREwOJizc4feugh3i6lvLzcZLDCsIDkzBnDi+fZs2fJxcWFAgMDTW4TGhra5H5ZbyK2KJGpYIUxFqwwLFhh2k7/sEVpPdZOQT9YYfSDFeaRVTercdivEPZFtOK+PEqN8KU9P53XZZKMGbPkC6uPC8DRyn/8jf9S7/byzQvxu5+d0D02f0gWPbziAP//w7cl8PY1zLcze/KARnvx9ljnzLMO7Je7NuOqr8MLW/nFnWVC/jU2t8lj+ej7X2nDodP0woB0nq1sjjZYYWa8/x3/caEfbAR43cwosEDjwImLvFqSOX/lGq+6bIgFVd1f2dFoPQsYWMDy3/2ndOu0wQrDAgt9R85e5kvuix/R6vsLeFsm7Y+d2rp6Xu2q/SE5vU8KHTpVpXvuE//9ii/6rw229Wu18VoPR7Ao78Y+MA8++CCtWbOGPv74Y4qLi2v2Ofn5+bxHkb4tW7ZQhw4dePsVU9sUFBRYcnjgIF/8/LvZ22p/NQ15+zPKnLmFJry7345HBuBYI//5OX127NaFX582WGG0wQrDgoLZm37Q3WfBitbmb8/wql+2NLy47zxyTvc9zLKQDZPjY9/ZR+sPnqbX9F5LG1SxYIZVebC2dwxrnN5Qw8zI/I+O8HZYLLCavOog/ffLUzy4YNkMlhFhPv7hV+r/+qd09Owlg/NtiDV83vrdrfZa5rpr4W7ehoRh7b9YFfLZ6ltZ9xc++J7eP3Ta4v2C9VgGUSgullYDsbYl69ev52OxaLMiLJXj4eHB/8+qfioqKmjZsmW6HkELFiygKVOm0H333cd7Bi1evNig98+kSZN449yXXnqJt4th+9+2bRuvbgLxYS3VAeCmexZ9ZnFRsAb5xryy5UeeXWjKvUu/4G3amMd7tqWJxQlG9/107xT+f9ZGhAVV+sofL6aXPrwVMJnC2tJp6Wcu2GsUJQbTvUv38fslc8pN7uf+fxtmUSzRbsYW3mOLNWBnxi27+ZogDNbeRxIZloULF/I6pm7duvHGstpl1apVum1Yu5QTJ26lRVkWZuPGjbR9+3Zq3749Pf/88zR//ny66667dNuwTMrKlStpyZIl1K5dO94Al+0zN7fp9CcAgNyYClYYbbDCsMagrLv59HVf8wyHPtZ99e3yYzTuncYX903fVJp9PPO2HTG6XpvtcRRtsMJ8pVcFBI5n684blmhRt2Yxsdc4LGJsdGsLB57pwce2MNecLYcpzM+DhuZG855Bw5ppRwMA8sa+Q7KeN6zKB/n7+58NmyXT6Bakj3XzMxcba0BbBx/g5Upn/my8CwDKtfzzW5l0AEdAwALNenL1rfFEJrxrfV00AMiHdnwSAEeR7lCE4DCs4R4AAIBKwCJAwKJQh381bKQHAAAgZghYFOrB5U2PmQAAAGCMkJPDImBRqMu10p/TAgAAlAMBC5gkk17vAAAgcQhYFMrcQGT+R4bDfAMAgHKpBHxtBCwKZW7e5NVthpMaAgAACAEBC/DZl9kCAABgSqC3+SOk2xoCFoVjVUO3v76Les/fiaAFAABM6poUTELBSLcKV/XHdfqm4ubAcGxK+xBfd6EPCQAARCgl3BfdmsHxtG1u9fvU30CPIAAAEGGDWwYZFgW7ePWaLnBhEK8AAEBTBBwzjkPAomDtZ22lcD9UAQEAQPOcBI5Y0OhW4SqraoQ+BAAAkACVwBkWBCygs+5gBUoDAABE2YYFAQvo/P3DwygNAAAwDlVCAAAAIHZqF2FzHMiwQJNuYPRbUKC/dG0j9CEAtEiwj9ouJejr7kpCQsACAAAgIx6uznbZLxrdAgCIiErwpoUA4qQReMo5ZFgAAET0KxIAjEPA0oyixCBSqmO/XRb6EAAAADgELM0YXRBLSvUSujmDAiHBAmKWGxfQ7DZhdpvEVtg6IQQszXBxVnIRCVxhCQAABiaXJDVbIjGBnrIsNSVfjc2iEbqVkYD0Z3IGUAp87EHqVHb66hb6coiABQycv1x768OBeAUUCL2EAMQJAQsYyHlhm+7/zohYAABERaXgH5IIWJqh3AohIncX+ww+BCBmCNRB6lR2ajou9PUQAQs0qTBBuV26QbnuLYwT+hAAmqRScBYGAUszZPq+mwW/NEGJ/DyFnS8FAIxDwAKKi9IBAEB6vWYtDljKy8upX79+FBERwbu9rlu3zuT2o0eP5ts1XNLS0nTbLF261Og2NTU1JDSh6+wAAADAioDlypUrlJmZSQsWLDBr+3nz5lFlZaVuOXnyJAUEBNDdd99tsJ2vr6/Bdmxxd7fXaH0AAADypJJpdtzF0ieUlZXxxVx+fn580WIZmQsXLtCYMWMMtmMZlbCwMEsPB+zg5O9XKSpAniMlAgBImcasrdBLyCYWL15MJSUlFBMTY7D+8uXLfF1kZCT17duXDhw4YHI/tbW1VF1dbbDYhQLrhKprrgt9CACikBzmI/QhAIAQjW5ZNc+mTZto3LhxBuuTk5N5O5YNGzbQihUreFVQYWEhHTlypMl9zZ49W5e9YUtUVJQDzkBZNn19RuhDABBUx9jmJ5oDcCSVgovboQELC0patWpFAwYMMFifl5dHw4cP521jioqK6L333qOkpCR67bXXmtzX1KlTqaqqSrewtjFgWx9+i4AFAEDq+rePoAi/W21Co62s8lfMXEKsO9Q///lPGjFiBLm5uZk+KCcn6tixo8kMi1qt5g119RcAAFuSa+NFUJZ592TRw90Tdfe3P9aNpMhhAcuOHTvo6NGjNHbsWLOCm4MHD1J4eLhDjs3ksSixEQsAAMgq0FbprXNyUtG03ikk+4CFNY5lwQRbmOPHj/P/nzhxQldVM3LkSKONbXNzcyk9Pb3RYzNnzqTNmzfTsWPH+L5YUMNuJ0yYYN1ZQYucvXRrxmYAAJAWlRnb3NelDcm+W/O+ffuouLhYd3/KlCn8dtSoUbyNCmtYqw1etFgbk9WrV/MxWYy5ePEijR8/ns6cOcMb0GZlZfEB6jp16kRCU+JU8x99/ysVtw0R+jAAAMAKGiOZFTlcyywOWLp162ZyeF4WtDTEgpCrV682+ZxXX32VL2KkxCohoRtWAYiF9L/iQW5UAjasEvrSgLmEoJGa6/UoFQAAic7no2ri/1KHgAUaQc8IAABx0li4jS4jI4PIBQELAACARKgc/XoqCc/WrDRozwGg3CH5+2e1FvpQACxuw6KyUZn99Y50Kn/8VicbyTW6BQCQuw0Pdqazl2oo0h+TgII0LBndkcYs/aLJ4MWaIGZYruGcf0JDhsVGIv09bLUrABCYm4sTghWQjKzoVlScfGsoCmNJmAAv0yPMSwEyLDaSGxdIpy6cIjlANRgAgHR4uDo3+Zg2eGFja40uiKWM1n4kVciwNAMXbwAAELMX78ho8jHtgHFsOP4Zt6fRXTmRusc+m9qdpAQBi43IqSuwnM4FAEBOVEa+n2ODvAy3MbPFSpifO/m4u0jmBzwCFgAAAAH1zgizadCgkumPTgQsILooGgBAKQZ1iKT2Ua1s0l7FKJV8pqpBo1sAAACR/kiMC/KiQC833v7ESaUiZyfLIpDmtm4T5EWHTlWRFCBgsQBrYb1098/2ezcAAAD0bJvSlViMovqznufwmUs2LZ/8+CDJBCyoErIAi3CVQOi0HwAA3MQyKi2ZoVnVzFMnFsdTd70xXMTcXAABSzNw6QYAAHvJifG3qJGsxoyrkv7uvNWuJrf1cXelxaM7khQgYAGjaq7fQMkAANjRK3dn0t05UTbfr0qloiVjOvI5sZaOkUYwYg60YYFGPviqktZ8WYGSASCi/z3Umfq+tgtlATanHcTNHlUtxW1D+GILfh6uVPXHdZvtz1oIWJoh9HTaQqitqxf6EABEI13CQ5mD/IX5utv9NbY+0oW++PkC9UwLJSEhYLERtQtq1wAAwHEeLE6gwR1tX6XUUIivO/VpF05Cw1XWRiaXJNlqVwAAoHAp4b6068niRuujAzx1/3+sZ1uK0rsvd8iwWKg0NZS2fPdro/XBPmpbvScAAKBw8cFeFOnfOBjxdHOhA8/0IBfnprsWBXi5kRwhw9KMhkMmKymaBQAA+7O0paS/lxvvjtyUIG/rf0CXpYcZ3IoJMixm1N19+tRt5K1GUQEAgLwVJQbTzP5pFOQlvloDXIXN0LqVh/3fCQAAABtQtXDCwxAf+/c8sgaqhCykwF7OAADQQHHbYLqvKA7l4kDIsAAAAPw5PIW541AtGdOJ376987hdyq4l8we1hEAvaxZkWABAFgoTAoU+BJDBRINCQObePAhYAEAW3h2bK/QhgMS1pHeNGEZZj/S/2d6ya1IwyRECFjsQY3cwALkTKoUO8jEiL4ak7ONHu9GXz/SgCJl2FEHAYgdtw3zssVsAALAjtau0L4luLk4tHjROzGG/tN8dAcQFYeA4AACwL2QMG0MvIQsN6RRNv12qpYKEILpn0WeWPh0A7ODO7NYoVwCZQ8BiaYE5O9GU0rb2eTcAwCqz78xAyYGkrH2gQOhDkByLq4TKy8upX79+FBERwVNW69atM7n99u3b+XYNlx9++MFgu9WrV1Nqaiqp1Wp+u3btWpIqlahrAQHkR+3iLPQhAFjUGykr2l+UJaZSyShguXLlCmVmZtKCBQsset7hw4epsrJStyQmJuoe27NnDw0ePJhGjBhBhw4d4reDBg2ivXv3klLd0zFK6EMAAACQbpVQWVkZXywVEhJCrVoZznysNXfuXOrRowdNnTqV32e3O3bs4OtXrFhBSpTW2o/oi5NCHwYAANiZxuL5mpXJYb2EsrKyKDw8nLp3706ffPKJwWMsw1JaWmqwrmfPnrR79+4m91dbW0vV1dUGi5z4uqN5EQCAI7mLqGpRxDUz8g1YWJCyaNEi3kZlzZo11LZtWx60sLYwWmfOnKHQ0FCD57H7bH1TZs+eTX5+frolKipKVnWAYhpxEUDqMOM6mOP29hGKLyiViEMluwcsLEC57777KDs7m/Lz8+mNN96gPn360Msvv2yyzzkblthUP3RWbVRVVaVbTp50fPWJi53nnXi6d7Jd9w+gFK8MyjRru2f6ptr9WOQuLsiLpMrdVTwZFhDJwHF5eXl05MgR3f2wsLBG2ZSzZ882yrroY72JfH19DRZHSwq174i2d2RF2nX/AHDL+omFNLZzHIqkhRJDvFGGIJ+A5cCBA7yqSItlXrZu3WqwzZYtW6igoEDR05yLuXsZgJSY86cUjwutTfRIbfqHJhiH2ZrNY3HLzsuXL9PRo0d1948fP04HDx6kgIAAio6O5lU1FRUVtGzZMv446+kTGxtLaWlpdO3aNXr33Xd5exa2aE2aNIm6dOlCL730EvXv35/Wr19P27Zto127dpGYDcuLpmlrv6FOsQEG6zMi/Xh1UV29htpF+tFXp6osHrUzJ8affr9yzcZHDKBM6IPhOD7urg58NanCJ9IhAcu+ffuouLhYd3/KlCn8dtSoUbR06VI+xsqJEyd0j7Mg5bHHHuNBjIeHBw9cPvjgA+rdu7duG5ZJWblyJU2fPp2eeeYZio+Pp1WrVlFurrinix/aKZoyWvvpqoY+erQr/XjmEnVLCqbDL5TRjXoNvb3zmMUBy5xB7e10xAAAIAWCZdhVJJ+ApVu3brxBbFNY0KLviSee4EtzBg4cyBcpYY2C20XeGlsmPtibL4yzisjZzo1yAQDAtjZP7kL7f7lAT6/9GkUrMpit2YG+mdmTXFkk04TMSD9afX++Iw8JAAD0tA3zoaG50SgTEULA4kDeaheK8vds8vGlYzpRToxhexgAABCXUF/bjpPVr93N8V9YEwOhGuK28rzZ9qggPpDECgGLxPylaxuhDwEAQNEKE4IsCm5W3JdncpvoQE869GwprZtYSELZ81R3+vzp7hRp4ke10DD+u52Zau9j3Q5tuzsAALAfdgnIijY+j54+vz8zHEI1uvVwc+aLmCHD4mCINwAA5G3B0CyhD0GWELDIbDh/AAAQzl/vSKe+f7ZJAdtClZCDeapR5AAAUpbXxnjD1DeHZ1OP1DCHH49SIMNiZ9kx/lY/t5WnG7k5O5nsCg1gb4UJ4u01YIq7qxP5urtgqAAHk/uUIqy6Z2B243ne2Hd1r/TwRuNvaRRQJo6Cn/t2VhAfREvHdKQ2QZZPCMY++F/NKOX/T37mQ36brtftDcARgrxt24XTUV4YkEEDc25eWD47dr7Z7VFdC+ZoWN3TJsiLjp27Ql3bBjf5HLWLuBuzSgUCFgfo1jakxdOdb32kCx06VUV924XTQysOWLWvh29LoPkf35oHCkDJPFydaVb/NPq1uoYSQ310f2ugTNaOrbJifB69f+g03Z0TZdPjQVKmMQQsDpYbF0CHTl60+HnsC5UtAI4W6e8hy0Jnmfu7O9j2IgPKE+rrTuOKLBsf64meyXY7HjlDGxYHe6QkiZ7pm0rbH+vm6JdGRSoYeH5AulklgkaEYK7yx29NjCs1KjvlNAK93BqtG9QRgbI1ELA4GBuYZ2znOIoN8rL7GC1zB2PWZ2hamK+7VcVTmhqKYoUmR2yVKo2Nv4H/NbYTdYoNoNeHZRus9xL54GxihoBFptQuTjQgq7XQhwEy5O3uQpNLEknq/tI1XuhDABkrSgym9ybkU3yw5R0uwDgELDKFbnRgt8+WDJoDjsqPoQeLE4Q+DLBSemtfi7bv0ILhJfS1i0QvTSGh0a2SOHr6TxA1/wZzlygJGx7ACaNOKyZoZu/3vl8utOg1dz5RzBvYOooKvzobQYZFpuTwKxjsh80e6+nmIswEngAioo1bMyMNJyiceXuawf2oAE9yc8ElU0gofQAFSghBvTooh6lkxZZHutBfurahv93VzmD9qIJYigqQZ5d+qULAIiK2/CUb5ue41CWAIz1V1vIxLJAzsh9H5Hb7t7dsckFTX60JIT40tSyFAox0P/Z0RasJMUHAIlPP9zdvjA0AqZmA3j2KN6YwjoJ9pDllhLkazkkECFhkq2OcbVrFg3zJPd2Nr3vpSTSzqpJdzNl4VvpWjs8jOXi6dzJFB3jSY6VthT4U0UGGRUCbJhXRAAtTm+bCZFvQ3CBZPu7m9RKKCWw8yCGArbsId0kKpid6mV/dN6Yw1uB+61a3AvCUcF965e5MSb5J47vEU/kTxajWNwIBi4DYHxUbph9AzFjdPps4UyvEykniAPRF+Hm0qB0f+1GWYWL2+nAbtONjDW+ZosSgFu8LWg4tikRUT+mEfvcgUklhtybedHXG7xwQhy5JQfR1RZXdGlYP6RRFWdGtMFqtSCBgEVgrTzca1CGSt2L3N9JKHUCMMNw42JoYx/thg7exTDiIAwIWEfj7QGnWtYJyBxbskxFOv1bX0AsffG+zY1IyVuWw88g5UjpbhixodC0/yO1KXKS/vHt6gDixYe3HFbUR+jBkA8OwWyfI+1Z7KmSo5Q8Bi8Rtm9JV6EMAECUpNQkTY3WIFAzNjeZVNuM6x5G3+laFgRjf+sd73uym3HBEXTAfAhaJc3d1FvoQQOT2TS9p8T70r6dRFmT1ZvU3nI/FVp63035BWlhPITY8xHQJ9LacWJxA38zsSf0y7TOUhRIgYAFQUNrcFu7MjjR725H5sfRAt3jd/Y6xthnQcER+LOXEYHBEJVZvPWnBWC3G/HtcLglFPwsElkPAoiRSypGDTbGeaGIYMrylky5mRt2aURefZmkrSAi06nn36wXApjRVyVaYgDFVpAoBC4BCeqJ9/nR3QV5b/8LR0qYaa+8vaOnhgAgMz4umYbkxDstAoI2QPCBgURI07FM0/V4Ufh7mDcsvxt5JtpAShrE1hNS/fWueqVs0IsdgfUF8IA3pFC3YcYHMApby8nLq168fRURE8LrKdevWmdx+zZo11KNHDwoODiZfX1/Kz8+nzZs3G2yzdOlSvq+GS01NjeVnBE1CPwT5WjqmY7PbsBFq908v4Yubi+N+q6hEViu5ZExHymgwj429FLcNdsjrSFVpWhhN651CgV5u9Fy/NP69P/vODKEPC0TK4m+tK1euUGZmJi1YsMDsAIcFLBs3bqT9+/dTcXExD3gOHDhgsB0LZiorKw0Wd/eWzwUBoATd2oaYtV2gt5ovwrE8YumaFMyHSP/fQ52b3VZ/xt6mgqNiM8vKFB93NJ60lfu6tOE92Vravgnkz+K/urKyMr6Ya+7cuQb3X3zxRVq/fj29//77lJWVpVvPIuuwsDBLDweI6Nm+qfTXjd+Th6szXa6ta7JMRPDjFuzg06duk3W5Bvuoafad7czKGOa1Md6Qk/2Ct6UJXePp/zYftuk+lQwD54Eo27DU19fTpUuXKCAgwGD95cuXKSYmhiIjI6lv376NMjAN1dbWUnV1tcGiVPd2jqPDz/eyWZdRkJbWrcQ92rFGBBWTiaE+PLB/fWi2QxtxohoWQMIByyuvvMKrlQYNGqRbl5yczNuxbNiwgVasWMGrggoLC+nIkSNN7mf27Nnk5+enW6KiokjJXDCDLkiAkO2+WWDfp104iU2Qt/ImPc1obf82RE56dYKtmxjssHtyy6sHwXEcWhHLgpEZM2bwKqGQkFsflLy8PL5osWAlOzubXnvtNZo/f77RfU2dOpWmTJmiu88yLEoPWgBAWr6d2ZM3hh77zhckFWzgtpc+/MHq5+fGBThkhO5OcQHUKTaA2gR70aiCWKq48AcVNwhQStNC7X4cIMGAZdWqVTR27Fj6z3/+QyUlpocKd3Jyoo4dO5rMsKjVar4AADn01yrYLqPkJcGRT5vrWc6CBFNiA73IEVi36fcm5Ovuz+yfrvv/2yM70O6fztFdFozaDAqpEmKZldGjR9Py5cupT58+ZtUPHzx4kMLDxZe+lRqkPOUtJtDT5vu8ryiu0bruKSGUHObDe+uYIzPSj168I6PRRRuzi8ufn6fxMX6Wj8ulO7Nb09TeLRta3xZ6pIbybtSoSpcWi8N71jj26NGjuvvHjx/nwQVrRBsdHc2raioqKmjZsmW6YGXkyJE0b948Xu1z5swZvt7Dw4O3PWFmzpzJH0tMTORVO6waiO3z9ddft92ZKlSYH7qGy9mK+25VpVpj2b2d6H9fnab39p3SrZvWJ5W+qaimPcfO69axFP6Hk7uYvd+Fw3Mowkhj4GgH/bq2N0838746zW2yc3/XeNp55ByJUXSAJ534/apFz3FxUlFdveHZFyQE8QXAYRmWffv28e7I2i7JrB0J+/+zzz7L77PxU06cOKHb/q233qK6ujqaOHEiz5hol0mTJum2uXjxIo0fP55SUlKotLSUBzxs/JZOnTpZfWJyVmjlHBwgP8aCAkt0SQrmw/bbcr4gU6zZq5ebde0dVHbqyL9wWDa1aiKLYC12IX9rRI4oG+C6u2JAdJBohqVbt24mu/Sx3j76tm/f3uw+X331Vb6AeW5LDqVPj9769avliIZsAOYI9XVvcuI5Nq7Kb5dqzdpPdnQrmlSSJKpCL8sIpzVf3spI3ZYcQh//cLbF++2ZFkalqaEUN3VjozFkzl+5RlLSsMkTy9I4QrifO1VW1fAqH5AfhM4yMr1vKiWFeuvaDoA8Pd6zLYldUxkaNrjhZ1O70/HZvc3az5oHCinAxoO+2do/Rzc/LUJLBlBLCfelokTHVKUYy/A4OznRv8beynZb2v76+1m96ONHu1qc+WOBWoiPZR0rNjzYmRYMzaKJxQmWHSRIgvSaqIPJAcS2PGLZFwNIj6cZVSTtIv3oq1NVJEb2qm6ClvP3dKPsaH/eZoV1BZ637QjNGZTJgyZreVhRpffOmI50o15DJXN2WPQ8lr3r2y7C4tcDaUDAAiAxbYK9Kb9NoMnMQ2ZkK9EELHLsEc0yReYwVX3OxmCxhazoVnTgxEWrn1+WHkabvrnZGYJZNLIDP26W7RFq5mT22i7OMvzgQIugSkiCrP0zxjDh8sASFCvG59Hrw5oeZr44OdiiC2tDSaE+JLRYO3TZthXWRqIkJaRR9Zy53b5tOQbL6gkFNm+4bc3cPvpPiQ/GRIZge8iwyJwcf91C89iMxP+ZkG/1hePR0iRydVbxBqYtFRdkXVdma4fR93V3oeqauiYnQrQFNn7HP0Y1bruSHGZ91Ym1nERYxbZoRAf6++Yf+CSRALaCgEVBQYj4vtbAnHZJFRf/sLig2C/kjs2MONrcr/+pvVPIFlj1lSN9Pq2ELtXU8fYMcnFvYZxunBa1ixPV1tXz/y+/L7fF+x6YE0mLdx1vcRY2RS9Yiw70pAU2mmgSQAtVQgAgK6x7v1DBSsMfE/pNWNiEf9ZWc7E5cD596jb66cXeBpmngviW9x5qSYNafa8Obm+T/QA0BQELAPD2GI6g5CrK9x/qzMdQspS2nQzLtom1hxXrutw2TPh2TyBvqBKSIEu+sgw6KSj5agEmxchkyHypdT9vzpZHuoiiAbQ9ui4DWAoZFglyc8GXg5KpZf7+3555cxyNobkxJDVuzre+Unc/dRtpWtg3z2iwgu5+oFAIWCSIzXjKhyzvnij0oYCDDWgfQR1j/W2+XzHl3ubd054Ov9CLV4GY8uCfo5n2by/8QGEP35ZAfTLCqWNcgMluyy0NYACUDFVCEm1UyIYsl/JFCSyX3tqX5t5zc9JROWM9nMzJIrGGqPuml/Ah3B2RObl2o57aNNFFe0rpzXYmx89dISH5ebhS1R/XLX7exOJ4ev2Tn+iZvql2OS4AW0CGBRTL0d1twfaCvNVWDXJmqfUPFvKqKkvnDWoTJI0B1B7vmUzfzepJXZNuDjgoxCzYAM1BwKIgaHNraEiuMMOOQ2Ntgr3459NRvZWs6fo7f0gWxVo4CF6or3TGgvF0Q8IdxA0Bi8whSAFzDMhqzW9TrRyTw6eFw8wnhnjTD8/3ordHdmjRfpQgSGQD4rH2O/aCrtKgDwELgMxYM1ZHems/2vt0d171YYm/3pHObxeYmNeIzVUTHeBJSaHefJRWY2bens7brTiiekfqHrwtgXpnhNGbw8Uxkqy2/Y49vHhHht32DdKDHKCCoO5Z3lbfn0+z3v+Onrs9zarnh/q6W/ycYbkxNLhDFJ9bx1QA9clj3XjLB2MByfP90yjMz/LXloKsaMMeXbE2GO/G192V3hiWY/Hs0FIU6C2ubBIICwELgEzkxATQ+gc7O/x1GwYrrMdJQ2IdodXeChOC6J+jO+gmoRyaG01nL9VQUWLzjVsBwBACFgCwqS6WXoxlXg2kPxy/q7MT75EjF2xGbwBHQcACAGAjMQGevEeRt9qZXBSaVQKwFwQsCiLzH7IAgnNyUtEHD3Xmf2toQAxgW+glBOBg+6eXoMxlHrQIFazIq8ktgCEELAAC9nzonBDU7PbabUbmx9r1uAAAxAwBi4Kw8TBAXNjcL81hw8FvntyF7s6JdMgxARjDxn5xc3GiO7JvDjII4Ghow6KgsVfQot98j5Qk0avbfiQxYBcJjPgJQnt9aDbV1Wt4TycAIeCTpyBoBGi+O0XyKxINpUFM3x8NgxWZjVMHIoeABQBA4txdncxuEwUgVagSUhD0aragrOxUWI/3NJx3xc+z+TYsAM35YloJ/X7lGr237yQKC2QLGRYABwr5c6bdOYMyqU9GOI3Mj0H5o16hxXzcXSmmmXmKPn+6Oz5rIGnIsIBiCZlxujM7ki/Hz10huUFbKeGYahAbYsXklgBiggyLgqABJ4C8jSmME/oQAOwGAQsAgILG9QGQKgQsoEj4YgeQHrT5UjaLA5by8nLq168fRURE8LrqdevWNfucHTt2UE5ODrm7u1ObNm3ozTffbLTN6tWrKTU1ldRqNb9du3atpYcGRpSlh/HbUN9bw8ErHRsU7v0HOwt9GABggXn3tKdZ/dNRZgpmccBy5coVyszMpAULFpi1/fHjx6l3795UVFREBw4coKeffpoefvhhHqBo7dmzhwYPHkwjRoygQ4cO8dtBgwbR3r17LT08aKAgIYg2TSqijx7thrJhvSnULjSpJJGiAz1FUR7Bf/YakhNPN2ehDwEAZMjiXkJlZWV8MRfLpkRHR9PcuXP5/ZSUFNq3bx+9/PLLdNddd/F17LEePXrQ1KlT+X12y7IybP2KFSssPURoICXct9Ew/SAO3moX2jalK5XM2UFSN71PCp268AelRdz8vIF1JnVPpHkfHUHxATi6DQvLnpSWlhqs69mzJw9arl+/bnKb3bt3N7nf2tpaqq6uNlgALCGWUcUTQrxJDsYVtaEZt6ehW3MLdYj1J6nwRSNfkFPAcubMGQoNDTVYx+7X1dXRuXPnTG7D1jdl9uzZ5Ofnp1uioqLsdAbygW7N0vP8ANTZg/j8a2wnnrl9Z0wnh8wSzQZcLEkxvEaA8rgIMZCU5s+RLfXXG9vG1ABUrNpoypQpuvssw4KgBWw5Q7IYFLcNIdlDJC05RYnBtGlSsMNmia7XEDk7oUpb6ez+rRwWFtYoU3L27FlycXGhwMBAk9s0zLroY72JfH19DRYwDX/u5gvxceyooMNyo/ntfUUY+AtAH/vhimAFHBKw5Ofn09atWw3WbdmyhTp06ECurq4mtykoKMC7BIow8/Y03tX6qbIUoQ8FBIbG8QA2qhK6fPkyHT161KDb8sGDBykgIID3BmJVNRUVFbRs2TL++IQJE3gXaFZ9c9999/EGtosXLzbo/TNp0iTq0qULvfTSS9S/f39av349bdu2jXbt2mXp4QFIkouzE2VE+gl9GAAA8smwsN49WVlZfGFYIML+/+yzz/L7lZWVdOLECd32cXFxtHHjRtq+fTu1b9+enn/+eZo/f76uSzPDMikrV66kJUuWULt27Wjp0qW0atUqys3Ntc1ZguyaCrTylOYQ5GLpmQQAIPsMS7du3XSNZo1hwUZDXbt2pS+//NLkfgcOHMgXAHPIKPYCsIsgbzc6d/kaShdkQxxdIcBBcJkHEDtXZ9v8nZalh9Oq8Xk22ReAYro1gzi4uyI+BRC7jrEBVNw2mOKC5DGgIICtIGBR2NgJcmFqjB4AKXNyUtESGw3IhjZTICf4ya0gGMsAAACkCgELAIBCDOl0c4BCH3ck10F68KkFyfJ0c6ar125Y/XxBKpWQowcHMVZrOuP2VCpNDeWPjV7yBd4LkBRkWECyvnymh8XPmdwjyS7HAiAFahdnKk4OIU83/FYF6cGnFiTL3dXZ7G2DvNX03wn5FBPoaddjApACtFkHKULAAorAJnqNDfIS+jDAGBMDUQIAaKFKCAAAAEQPAQsoQoivWuhDAACAFkDAAoqwYEi20IcAAAAtgIAFFAHtV0CJgn2MZxZbeUhztnNQNjS6BQBhocuK3cQHe9Pf72rXKHBJDPWhJ3q1pRAfd/u9OICNIWABScJMQgDmGdQxyuj6B7oloAhBUlAlBLL0qEgHiNNgqFtwEAT1IDcIWECWHuqeSD5qJBABAOQCAQsAAACIHgIWUKymxleND8aIuAAAYoOABaCB5HBflAkAgMggYAFoyAZT20wuSaTn+qWibAEAbAQBC4AdTC5JojGFcShbAAAbQcACAAAAooeABcCOXJ0xGgYIw93NGUUPsoKABRTLEaHExoeLaHRBrANeCeCmmbenUVZ0K3qgK0ayBXlBwAKSJLbpZ+7Iam10PZuzZcbtaQ4/HlCuUQWxtPaBQvLzxASHIC8IWABsMHz+nEGZ1K1tMMoSAMBOELAA2IBKpSI/D/yiBQCwFwQsAAAAIHoIWACa0bqVB8oIAEBgCFgAmjGpJBFlBAAgMAQsAM0QWYckAABFQsACkrBvegkNzIkkqdPYYJ4iuUkI9hb6EABArgHLG2+8QXFxceTu7k45OTm0c+fOJrcdPXo070HRcElLuzU2xdKlS41uU1NTY91ZgewEeavJy9KROx2cGgnwcnPsC0rc+w92plcHZ1J+fKDQhwIAcgxYVq1aRZMnT6Zp06bRgQMHqKioiMrKyujEiRNGt583bx5VVlbqlpMnT1JAQADdfffdBtv5+voabMcWFhABOEJ+m5ZfNNuG+tjkWJQiI9KP7siSftYMAEQasMyZM4fGjh1L48aNo5SUFJo7dy5FRUXRwoULjW7v5+dHYWFhumXfvn104cIFGjNmjMF2LKOivx1bABxlxfg8h7wOaoQAABwQsFy7do32799PpaWlBuvZ/d27d5u1j8WLF1NJSQnFxMQYrL98+TJfFxkZSX379uXZG1Nqa2upurraYAElEV9TWLFNFwAAoNiA5dy5c3Tjxg0KDQ01WM/unzlzptnns2qeTZs28eyMvuTkZN6OZcOGDbRixQpeFVRYWEhHjhxpcl+zZ8/m2RvtwrI8AAAAIE9WNbpl1Tf6NBpNo3XGsKCkVatWNGDAAIP1eXl5NHz4cMrMzORtYt577z1KSkqi1157rcl9TZ06laqqqnQLaxsD8mbOZ0zInjzoAQQAYD8ulmwcFBREzs7OjbIpZ8+ebZR1aYgFNf/85z9pxIgR5OZmujeFk5MTdezY0WSGRa1W8wUAAADkz6IMCws0WDfmrVu3Gqxn9wsKCkw+d8eOHXT06FHeYLc5LLg5ePAghYeHW3J4AHbh6ozhigAAJJVhYaZMmcKzJB06dKD8/HxatGgR79I8YcIEXVVNRUUFLVu2rFFj29zcXEpPT2+0z5kzZ/JqocTERN54dv78+Txgef3111tybgA2oXZxojeGZdP1G/U0aeVBlCoAgBQClsGDB9P58+dp1qxZvBEtC0A2btyo6/XD1jUck4W1MVm9ejUfk8WYixcv0vjx43lVE2tAm5WVReXl5dSpUydrzwvApnpn3Mz2IWABAJBIwMI88MADfGmqYW1DLAi5evVqk/t79dVX+QLgSF3bBpObsxO1j2qFggcAkGPAAiAHvu6u9PXMUh606ENvHwAA8UFrQpANZ6eb3Z7jgrzMfo7axdlh3aUBAMB6yLCAbKy+v4D+tecXerh7ws0VGAcfAEA2ELCAJBlLiiSGeNMrgzKFOBwAALAzVAkB2Ig5NUtoHwMAYB0ELABWCvN157etW3mgDAEA7AxVQgANaMxs/LJifB69uf0nur9bPMoQAMDOELAANCMx1MfoetYb6aWB7VB+AAAOgCohkLSnypKbfrCFvZU/erQrrRyfRwkh3i3bEQAAtBgCFpC0fpkRdtt3fLA35bUJtNv+AQDAfAhYAAAAQPQQsACItOvxbckhQh8CAIBoIGABUcuJ8acPJxeREt2R1VroQwAAEA0ELCBqj/ZIouQwX6EPAwAABIaABSQJ0xUCACgLAhYAGwn2UaMsAQDsBAELgAUWDssmPw9X+tfYTo0eK24bQg90i6c3hmWjTAEAbAwj3QI04K1u+s+iLCOceqWHkcrITIds3RO9TAxkBwAAVkOGBeBPL9+dSe2jWpkePffPwAQAABwLGRaAPw3MieQLAACIDzIsIDprHygQ+hAAAEBkELCA6EQFeJJceamdhT4EAABJQsACkiHlpiPP9UulsvQw6pMR3uy2RYlB5OXmTN3aBjvk2AAApABtWEDURDKtT4uNKYzjizmW3duJ6uo15OqM3xMAAFoIWEB0VCKciNCRWC8kV2cJp5MAAOwAP+FAdMzpNizl6iEAALAcAhYQNQQmAADAIGABAAAA0UPAArKFWiMAAPlAwAKC6JUWZpP9aJTYKhcAQIEQsIAgctsE2HyfaO8CACBfCFjA4dJb+9LgjlEWP0+FSh4AAMXCOCzgUO0i/WjDg51R6gAAYP8MyxtvvEFxcXHk7u5OOTk5tHPnzia33b59Ox9Xo+Hyww8/GGy3evVqSk1NJbVazW/Xrl1rzaGBzKCJCgAAWBWwrFq1iiZPnkzTpk2jAwcOUFFREZWVldGJEydMPu/w4cNUWVmpWxITE3WP7dmzhwYPHkwjRoygQ4cO8dtBgwbR3r178S4pEHr3AABAiwOWOXPm0NixY2ncuHGUkpJCc+fOpaioKFq4cKHJ54WEhFBYWJhucXa+NWst20ePHj1o6tSplJyczG+7d+/O1wMYkxLui4IBAFAQiwKWa9eu0f79+6m0tNRgPbu/e/duk8/Nysqi8PBwHoh88sknBo+xDEvDffbs2dPkPmtra6m6utpgAWHMvD2NPN1uBaC2FBvkaXT9/w3MtMvrAQCADAKWc+fO0Y0bNyg0NNRgPbt/5swZo89hQcqiRYt4G5U1a9ZQ27ZtedBSXl6u24Y915J9MrNnzyY/Pz/dwrI8IIyC+EB6pCTJLvtWuxgPhIJ91HZ5PQAAkFEvoYaT07HBu5qasI4FKGzRys/Pp5MnT9LLL79MXbp0sWqfDKs2mjJliu4+y7AgaAEAAJAnizIsQUFBvO1Jw8zH2bNnG2VITMnLy6MjR47o7rM2LZbuk/Um8vX1NVhAGI4asC3Q280xLwQAANIOWNzc3Hg35q1btxqsZ/cLCgrM3g/rXcSqivSzLg33uWXLFov2CfJ3b2Ec9cuMoNeGZAl9KAAAIPYqIVYNw7odd+jQgQcarH0K69I8YcIEXVVNRUUFLVu2jN9nPX1iY2MpLS2NN9p99913eXsWtmhNmjSJVw+99NJL1L9/f1q/fj1t27aNdu3aZctzBYnzcHNGsAIAoFAWByxsvJTz58/TrFmz+Hgq6enptHHjRoqJieGPs3X6Y7KwIOWxxx7jQYyHhwcPXD744APq3bu3bhuWSVm5ciVNnz6dnnnmGYqPj+fjveTm5trqPMGOIlp5mL1tpL/52zIawuSGAABgZaPbBx54gC/GLF261OD+E088wZfmDBw4kC8gLV8+04M83Zr/GDk7qahPRjg90ze12W0xiSEAADSEuYSgRQK8zGsImxsXQPPR9gQAAKyE2ZoBAABA9BCwgGwlhHgLfQgAAGAjCFhAtl4bmk13ZrWm/z3UWehDAQCAFkIbFrAJW/XmGds5jmyldSsPmjO4vc32BwAAwkHAAqKx5ZEulBDsTdU114U+FAAAEBkELCAaSaE+Qh8CAACIFNqwgLhh3DgAAEDAAmKkIgfNpggAAJKBDAsAAACIHgIWAAAAED0ELAAAACB6CFjAIW5LDmn6Q6gi2jalC94JAABoEgIWsJq7a9MfnzuzWxvcH10Q2+S2XZKCKSEEXZoBAKBpCFjAamvuL2zysTuybgUsPdNCycW56Y+aBl2XAQCgGQhYwGoebs4oPQAAcAgELCBqSL4AAACDgAWs5qV2Frxax1t9a3YJZ9Z6FwAAZAlzCYHVMyGH+Libta3FwYwFcUcrTzead097cnV2IrULqqgAAOQKAQtYZUinKNGUXP/2hj2SAABAflAlBFZxdsJHBwAAHAdXHbDK8LxolBwAADgMAhawio+7K0oOAAAcBgELAAAAiB4CFgAAABA9BCxgFypL+iYDAAA0AwEL2E2wj5rflqaFWT0YnL+nm82PCwAApAfjsIDdbJnchb49XU0F8YEWPY+NWPv1jFKq1xC5uSCmBgAABCxgR/5ebtQ5MajJx1kwcq2unoqMbINeSAAAoA8ZFhDM9se60efHf6e+7cLxLgAAgEnIt4NNDMyJJA9Xy+byiWjlQQOyWpOLMz6GAABgGq4UYBOB3mr6akYpShMAAOwCAQvYDJsxGQAAwB6susK88cYbFBcXR+7u7pSTk0M7d+5scts1a9ZQjx49KDg4mHx9fSk/P582b95ssM3SpUtJpVI1Wmpqaqw5PAAAAFB6wLJq1SqaPHkyTZs2jQ4cOEBFRUVUVlZGJ06cMLp9eXk5D1g2btxI+/fvp+LiYurXrx9/rj4WzFRWVhosLCAC4b33l3x6dXAmBXljTBQAAJBIL6E5c+bQ2LFjady4cfz+3LlzecZk4cKFNHv27Ebbs8f1vfjii7R+/Xp6//33KSsrS7eeZVTCwiwbYAwco1NcABEF0Fs7jtG5y9dQ7AAAIO4My7Vr13iWpLTUsHElu797926z9lFfX0+XLl2igAB2Ebzl8uXLFBMTQ5GRkdS3b99GGRgQ3hvDsim/TSD9e1yu0IcCAAAKY1GG5dy5c3Tjxg0KDQ01WM/unzlzxqx9vPLKK3TlyhUaNGiQbl1ycjJvx5KRkUHV1dU0b948KiwspEOHDlFiYqLR/dTW1vJFiz0P7KtNsDetGJ+HYgYAAGkMHMeqb/RpNJpG64xZsWIFzZgxg1cJhYSE6Nbn5eXxRYsFK9nZ2fTaa6/R/Pnzje6LVT/NnDnTmsMHAAAAOVcJBQUFkbOzc6NsytmzZxtlXYw11mVtX9577z0qKSkxfVBOTtSxY0c6cuRIk9tMnTqVqqqqdMvJkyctORWwMw83ywaRAwAAsFnA4ubmxrsxb9261WA9u19QUGAyszJ69Ghavnw59enTp9nXYRmbgwcPUnh400O2q9Vq3rNIfwHhPd07mYblRlN2dCuhDwUAAJRcJTRlyhQaMWIEdejQgY+psmjRIt6lecKECbrMR0VFBS1btkwXrIwcOZK3S2HVPtrsjIeHB/n5+fH/s6od9hhrr8LaorBqIBawvP7667Y9W6B2kX701akqu5XE+C7xKGUAABA+YBk8eDCdP3+eZs2axcdKSU9P52OssB4+DFunPybLW2+9RXV1dTRx4kS+aI0aNYo3tGUuXrxI48eP58EMC2JYd2c2fkunTp1sc5ag4+fhitIAAADJUWlY/YsMsMwMC3ZYexZUDzVtxOK9tPPIOYvK9ue/NV+NBwAAYM/rNyZ/UbieaaYbSwMAAIgBAhaFkUc+DQAAlAYBi8JoCBELAABIDwIWhTGWYdk0qUiIQwEAADAbAhaFMRawpIT7UkKItxCHAwAAYBYELAqvElJR81MqAAAACA0Bi8Kg0S0AAEgRAhaFQZNbAACQIgQsStNExIKKIQAAEDMELAqDbs0AACBFCFgUBo1sAQBAihCwKMwLd6QLfQgAAAAWQ8CiMEmhPkIfAgAAgMUQsAAAAIDoIWABAAAA0UPAAgAAAKKHgAVMCvFRo4QAAEBwCFgUaN497ZvdplNcAC0e1QEzOQMAgCggYFGg/u1bm3x8VH4MLRiSRd1TQinQGxkWAAAQnovQBwDi4ON+66Mwsz/GagEAAHFBhkXhOsT689tXBrWnjNZ+9ObwbKEPCQAAoBGVRqORxQS+1dXV5OfnR1VVVeTr6yv04Yje8XNXaM9P5+nuDpHk6oy4FQAAxH39RpWQQsUFefEFAABACvDTGgAAAEQPAQsAAACIHgIWAAAAED0ELAAAACB6CFgAAABA9BCwAAAAgOghYAEAAADRQ8ACAAAAooeABQAAAEQPAQsAAACIHgIWAAAAED0ELAAAACB6CFgAAABA9GQzW7NGo9FNUw0AAADSoL1ua6/jsg9YLl26xG+joqKEPhQAAACw4jru5+fX5OMqTXMhjUTU19fT6dOnycfHh1QqlU0jPxYEnTx5knx9fUmJlF4GSj9/RullgPNX9vvP4DNQbbfPAAtDWLASERFBTk5O8s+wsJOMjIy02/7ZG6TUP1QtpZeB0s+fUXoZ4PyV/f4z+Az42uUzYCqzooVGtwAAACB6CFgAAABA9BCwNEOtVtNzzz3Hb5VK6WWg9PNnlF4GOH9lv/8MPgNqwT8Dsml0CwAAAPKFDAsAAACIHgIWAAAAED0ELAAAACB6CFgAAABA9BQRsCxcuJDatWunG/AnPz+fNm3apHuctTueMWMGH2XPw8ODunXrRt9++63BPmpra+mhhx6ioKAg8vLyottvv51OnTplsM2FCxdoxIgRfAActrD/X7x4kcRm9uzZfDTgyZMnK6IM2Hmx89VfwsLCFHHu+ioqKmj48OEUGBhInp6e1L59e9q/f78iyiE2NrbRZ4AtEydOlP25a9XV1dH06dMpLi6On2ObNm1o1qxZfJRwLbmXAxtNlX3vxcTE8PMrKCigL774QrbnX15eTv369ePnwz7v69atM3jcked74sQJfixsH2xfDz/8MF27ds2yE9IowIYNGzQffPCB5vDhw3x5+umnNa6urppvvvmGP/63v/1N4+Pjo1m9erXm66+/1gwePFgTHh6uqa6u1u1jwoQJmtatW2u2bt2q+fLLLzXFxcWazMxMTV1dnW6bXr16adLT0zW7d+/mC/t/3759NWLy+eefa2JjYzXt2rXTTJo0SbdezmXw3HPPadLS0jSVlZW65ezZs4o4d63ff/9dExMToxk9erRm7969muPHj2u2bdumOXr0qCLKgb3f+u8/O3729ffJJ5/I/ty1XnjhBU1gYKDmf//7H3////Of/2i8vb01c+fO1W0j93IYNGiQJjU1VbNjxw7NkSNH+HeDr6+v5tSpU7I8/40bN2qmTZvGz4d93teuXWvwuKPOl23L1rHnsn2wfUVERGgefPBBi85HEQGLMf7+/pp//OMfmvr6ek1YWBh/47Rqamo0fn5+mjfffJPfv3jxIg9wVq5cqdumoqJC4+TkpPnwww/5/e+++45/ID777DPdNnv27OHrfvjhB40YXLp0SZOYmMg/LF27dtUFLHIvA/alxP7AjJH7uWs9+eSTms6dOzf5uFLKQYt99uPj4/l5K+Xc+/Tpo7n33nsN1t15552a4cOH8//LvRyuXr2qcXZ25gGbPvbdwC7qcj9/ahCwOPJ8WeDEnsOeq7VixQqNWq3WVFVVmX0OiqgS0nfjxg1auXIlXblyhVcNHT9+nM6cOUOlpaW6bdjAOF27dqXdu3fz+yxtfv36dYNtWAotPT1dt82ePXt4Kiw3N1e3TV5eHl+n3UZoLP3dp08fKikpMVivhDI4cuQIP16WDr/nnnvo2LFjijl3ZsOGDdShQwe6++67KSQkhLKysujtt9/WPa6UcmBYGvrdd9+le++9l6fJlXLunTt3po8++oh+/PFHfv/QoUO0a9cu6t27N78v93JgVWLs+9/d3d1gPasKYeUg9/NvyJHny7Zhz2HP1erZsyevbtKvlm6OYgKWr7/+mry9vfkbMmHCBFq7di2lpqbyN4wJDQ012J7d1z7Gbt3c3Mjf39/kNuxC0BBbp91GSCxI+/LLL3n7lYbkXgbsD2nZsmW0efNmfpFmx8Lqrs+fPy/7c9diARpry5WYmMjLgf0NsDpkVi6MUsqBYfX4rH599OjRijr3J598koYMGULJycnk6urKg1bWnoOtU0I5+Pj48B+pzz//PJ0+fZoHLyxw3bt3L1VWVsr+/Bty5Pmy24avw/bJ9m1JmchmtubmtG3blg4ePMi/qFavXk2jRo2iHTt26B5nv7T0sQxaw3UNNdzG2Pbm7Mfe2HTgkyZNoi1btjT6daFPrmVQVlam+39GRgb/0oqPj6d33nmH/xKQ87lrsYaVLMPy4osv8vvsYsUa17EgZuTIkbrt5F4OzOLFi/lnQv/XnhLOfdWqVfwCvXz5ckpLS+PfhyxgYeXAvg+VUA7/+te/eGatdevW5OzsTNnZ2TR06FD+Y04J52+Mo87XFmWimAwLi+QSEhL4lzbLMmRmZtK8efN0vUUaRnlnz57VRYRsG5ZGZi2hTW3z66+/Nnrd3377rVFk6Wgs5caONScnh1xcXPjCgrX58+fz/2uPT85loI+1UmeBC6smUsL7z4SHh/OMor6UlBTecp9RSjn88ssvtG3bNho3bpxunVLO/fHHH6ennnqKV4myzz/ryfHII4/osq5KKAf2Q4V9912+fJn/kPv88895lQerKlbC+etz5PmybRq+DtsnK3tLykQxAYuxyI7Vn2k/qFu3btU9xt4g9qFm1QYMu9CzFKr+NiyF+M033+i2Yb/aq6qq+B+AFks1snXabYTSvXt3XiXGflFpFxa4DRs2jP+fdW+UexnoY+/7999/zy/iSnj/mcLCQjp8+LDBOtaWgXXvZJRSDkuWLOGpataWS0sp53716lVycjL8ymdZBm23ZqWUg/ZHC/v7ZxdNVkXav39/RZ0/48jzZduw57DnarGMP2uiwV7DbBoFmDp1qqa8vJx35fvqq694t2bWYnnLli38cdZKmrWMXrNmDe/aNWTIEKNduyIjI3lXUNYt67bbbjPatYt1F2YtpNmSkZEhiq58xuj3EpJ7GTz66KOa7du3a44dO8ZbsrPjYV35fv75Z9mfu353dhcXF81f//pX3p3z3//+t8bT01Pz7rvv6raRezncuHFDEx0dzXtMNST3c2dGjRrFu6dquzWzcw0KCtI88cQTiikH1rNl06ZN/LuAff+z4+7UqZPm2rVrsjz/S5cuaQ4cOMAXdrmfM2cO//8vv/zi0PPVdmvu3r073wfbF9snujUbwbrysTEo3NzcNMHBwbzQtMGKtnsX6/rKunixblZdunThb56+P/74gxduQECAxsPDg78ZJ06cMNjm/PnzmmHDhvGLIVvY/y9cuKCRQsAi5zLQji3Auuexvv+sK+e3336riHPX9/777/MvDXaOycnJmkWLFhk8Lvdy2Lx5M//SZmMxNST3c2fYRYj9zbOgzd3dXdOmTRvenbe2tlYx5bBq1Sp+3uxawM5x4sSJvOuuXM//k08+4Z/5hgsLXh19vixIYl3r2T7Yvtg+WTdqS6jYP+bnYwAAAAAcT7FtWAAAAEA6ELAAAACA6CFgAQAAANFDwAIAAACih4AFAAAARA8BCwAAAIgeAhYAAAAQPQQsAAAAIHoIWAAAAED0ELAAAACA6CFgAQAAANFDwAIAAAAkdv8PvS5nc8JYQbkAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 640x480 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "plt.plot(vws, spectra_body1[0, :, 0]/spectra_body1[0, :, 1]+spectra_body2[0, :, 0]/spectra_body2[0, :, 1])\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c35f426f",
-   "metadata": {},
-   "source": [
-    "## Save the spectra and meshes"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "02cfd4f2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "os.makedirs(output_dir, exist_ok=True)\n",
-    "\n",
-    "with open(f'{output_dir}/tz_fornacis_data_{num_wavelengths}.pkl', 'wb') as f:\n",
-    "    pickle.dump({\n",
-    "        'spectra_body1': spectra_body1,\n",
-    "        'spectra_body2': spectra_body2,\n",
-    "        'mesh_body1': pb1,\n",
-    "        'mesh_body2': pb2,\n",
-    "        'wavelengths': vws,\n",
-    "        'times': times\n",
-    "    }, f)\n",
-    "\n",
-    "print(f\"\\u2713 Spectra data saved to {output_dir}/tz_fornacis_data_{num_wavelengths}.pkl\")"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "astro",
-   "language": "python",
-   "name": "astro"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.15"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }


### PR DESCRIPTION
* tz_fornacis_spectra.ipynb now computes the primary/secondary eclipse windows with eclipse_timestamps_kepler (re-used from check_phoebe_eclipses.py) right after add_orbit, overlays them on the Gaia G lightcurve, and persists them in the saved pickle.
* New tz_fornacis/tz_fornacis_lightcurves.{py,pbs} runs a single GPU job that synthesizes both sweeps from the same binary config — a uniform general lightcurve and a dense eclipse-windowed sweep — and writes one pickle per sweep using the filename convention already consumed by tz_fornacis_lightcurve_plot.ipynb.