### PR TITLE
check_phoebe_eclipses.pbs: convert to PBS array job with resumable OU…

### DIFF
--- a/tutorial/paper_results/check_phoebe_eclipses.pbs
+++ b/tutorial/paper_results/check_phoebe_eclipses.pbs
@@ -1,45 +1,59 @@
 #!/bin/bash
-# Gadi PBS script: run check_phoebe_eclipses.py in grid mode on one node,
-# parallelizing across all CPUs via the script's --grid-config / --n-workers
-# multiprocessing pool.
+# Gadi PBS ARRAY script: run check_phoebe_eclipses.py concurrently across
+# many nodes. Each array element processes a deterministic round-robin slice
+# of the parameter grid; all elements share OUTPUT_DIR so the per-task pickle
+# resume logic deduplicates results across the whole array.
 #
 # === Edit these before submission ============================================
 # 1. Replace <PROJECT> below with your NCI project code (e.g. ab12).
-# 2. Adjust the queue / walltime / mem if your grid is larger or smaller than
-#    the default ~few-hundred tasks.
-# 3. Set SPICE_VENV (or the `module load`/conda activate block) to whatever
+# 2. ARRAY_SIZE is the upper bound in `#PBS -J 1-N` below. If you change the
+#    directive, also export ARRAY_SIZE=N before qsub (or edit the default in
+#    the "Array bookkeeping" section) so the slicer matches.
+# 3. Per-element resources (ncpus / mem / walltime) are sized for ~50 grid
+#    points per element. Scale them with ARRAY_SIZE.
+# 4. Set SPICE_VENV (or the `module load`/conda activate block) to whatever
 #    Python environment has spice + phoebe + transformer-payne installed.
-# 4. Edit the `# --- grid definition ---` block (or supply your own CSV) to
-#    cover the parameter combinations you want.
+# 5. Edit the `# --- grid definition ---` block (or supply your own CSV via
+#    GRID_CSV=...) to cover the parameter combinations you want.
+# 6. (Optional) Set RUN_NAME to label this sweep — it becomes the OUTPUT_DIR
+#    subdirectory. Resubmitting with the same RUN_NAME resumes; with a fresh
+#    RUN_NAME starts a clean run alongside the old one.
 #
 # Submit with:    qsub tutorial/paper_results/check_phoebe_eclipses.pbs
-# Resume after a timeout: just resubmit — already-finished tasks are skipped.
+# Resume after a timeout / failure / mass abort: just resubmit. Every
+# completed pickle in OUTPUT_DIR is skipped, so only unfinished grid points
+# are recomputed. Resume works across:
+#   * walltime kills of individual array elements,
+#   * full-array failures,
+#   * changing ARRAY_SIZE between submissions (slices are recomputed),
+#   * extending the grid definition (new rows are picked up, old skipped).
 #
 # Error policy (matches the Python script):
 #   * PHOEBE "model not converged" and "failed to pass checks" failures
 #     (e.g. components overflowing at periastron at the requested geometry)
-#     are skipped per-task; the grid keeps running and the job exits 0 if
-#     every other task succeeded.
-#   * Any other exception aborts the run — the worker pool is terminated,
-#     python exits non-zero, and `set -euo pipefail` below propagates that
-#     to PBS so the job is marked failed (and `#PBS -m abe` emails you).
-#     Already-finished pickles in OUTPUT_DIR are preserved, so resubmitting
-#     after a fix resumes from where it stopped.
+#     are skipped per-task; the array element keeps running and exits 0 if
+#     every other task in its slice succeeded.
+#   * Any other exception aborts that array element's worker pool; python
+#     exits non-zero and `set -euo pipefail` propagates that to PBS so the
+#     element is marked failed. Other array elements continue independently.
+#     Already-finished pickles in OUTPUT_DIR are preserved.
 # =============================================================================
 
 #PBS -P mk27
 #PBS -q rsaa
-#PBS -l ncpus=104
-#PBS -l mem=400GB
-#PBS -l walltime=48:00:00
-#PBS -l jobfs=20GB
+#PBS -J 1-10
+#PBS -l ncpus=16
+#PBS -l mem=128GB
+#PBS -l walltime=24:00:00
+#PBS -l jobfs=10GB
 #PBS -l storage=scratch/y89+gdata/y89+scratch/mk27
 #PBS -l wd
 #PBS -N spice_eclipses
 #PBS -j oe
 #PBS -m abe
 #PBS -M maja.jablonska@anu.edu.au
-# (optional) email on abort/begin/end — comment out if undesired
+# (optional) email on abort/begin/end — note: -m abe fires per array element,
+# so 25 elements => up to 25 emails. Comment out if undesired.
 
 set -euo pipefail
 
@@ -66,28 +80,70 @@ export XLA_PYTHON_CLIENT_ALLOCATOR=platform
 cd "${PBS_O_WORKDIR}"
 
 # ---------------------------------------------------------------------------
-# Output paths — write to /scratch so we don't fill the home volume
+# Array bookkeeping
+# ---------------------------------------------------------------------------
+# PBS_ARRAY_INDEX is set per element (1..ARRAY_SIZE). When running this script
+# outside PBS (smoke test on the login node), it defaults to a 1/1 single run.
+ARRAY_INDEX="${PBS_ARRAY_INDEX:-1}"
+# Must match the upper bound in `#PBS -J 1-N` above. Override by exporting
+# ARRAY_SIZE before qsub if you change the directive.
+ARRAY_SIZE="${ARRAY_SIZE:-10}"
+
+# ---------------------------------------------------------------------------
+# Output paths — write to /scratch so we don't fill the home volume.
+# All array elements share OUTPUT_DIR so the script's "skip already-done"
+# logic deduplicates across the whole array.
+#
+# OUTPUT_DIR is intentionally NOT tied to PBS_JOBID, so resubmitting after a
+# timeout/abort/scale-change writes to the same place and reuses the existing
+# pickles. Set RUN_NAME to keep separate sweeps in separate directories.
 # ---------------------------------------------------------------------------
 PROJECT="$(echo "${PBS_O_WORKDIR}" | awk -F/ '{for(i=1;i<=NF;i++) if($i=="scratch"){print $(i+1); exit}}')"
 PROJECT="${PROJECT:-y89}"
-OUTPUT_DIR="${OUTPUT_DIR:-/scratch/${PROJECT}/${USER}/spice_eclipses/${PBS_JOBID%.*}}"
-GRID_CSV="${GRID_CSV:-${OUTPUT_DIR}/grid.csv}"
+RUN_NAME="${RUN_NAME:-default}"
+OUTPUT_DIR="${OUTPUT_DIR:-/scratch/${PROJECT}/${USER}/spice_eclipses/${RUN_NAME}}"
 mkdir -p "${OUTPUT_DIR}"
 
 # ---------------------------------------------------------------------------
-# Grid definition
+# Grid definition — per-element slice (round-robin)
 # ---------------------------------------------------------------------------
-# If the user already has a grid CSV, point GRID_CSV at it and skip generation.
-# Otherwise build a default sweep here. Columns: inclination,period,q,ecc,
-# primary_mass,n_times,n_mesh_elements.
+# Each array element writes its own slice CSV containing only the rows it is
+# responsible for. The slice is round-robin by row index so any natural
+# ordering bias in difficulty (e.g. high-eccentricity rows being slowest) is
+# spread evenly across elements rather than piling onto the last few.
+#
+# If the user supplies a master GRID_CSV via the environment, we slice that
+# instead of generating one. Otherwise we build the default sweep inline.
 #
 # N_MESH_ELEMENTS sets both the SPICE icosphere subdivision count and PHOEBE's
 # ntriangles, so the two codes are compared at matching surface resolution.
 N_MESH_ELEMENTS="${N_MESH_ELEMENTS:-1000}"
-if [[ ! -s "${GRID_CSV}" ]]; then
-    N_MESH_ELEMENTS="${N_MESH_ELEMENTS}" python3 - "${GRID_CSV}" <<'PY'
+USER_GRID_CSV="${GRID_CSV:-}"
+# Slice CSV is regenerated every run — it's cheap and the partitioning depends
+# on ARRAY_SIZE, which the user may change between submissions. A stale slice
+# would either miss rows or double-assign them across elements.
+TASK_GRID_CSV="${OUTPUT_DIR}/grid_task_${ARRAY_INDEX}.csv"
+
+if [[ -n "${USER_GRID_CSV}" && -s "${USER_GRID_CSV}" ]]; then
+    python3 - "${USER_GRID_CSV}" "${TASK_GRID_CSV}" "${ARRAY_INDEX}" "${ARRAY_SIZE}" <<'PY'
+import sys
+src, dst, idx, size = sys.argv[1], sys.argv[2], int(sys.argv[3]), int(sys.argv[4])
+with open(src) as fi, open(dst, "w") as fo:
+    header = fi.readline()
+    fo.write(header)
+    for i, line in enumerate(fi):
+        if (i % size) == (idx - 1):
+            fo.write(line)
+PY
+    echo "Sliced ${USER_GRID_CSV} → ${TASK_GRID_CSV} (element ${ARRAY_INDEX}/${ARRAY_SIZE})"
+else
+    ARRAY_INDEX="${ARRAY_INDEX}" ARRAY_SIZE="${ARRAY_SIZE}" \
+        N_MESH_ELEMENTS="${N_MESH_ELEMENTS}" python3 - "${TASK_GRID_CSV}" <<'PY'
 import csv, os, sys
 import numpy as np
+
+array_index = int(os.environ["ARRAY_INDEX"])
+array_size  = int(os.environ["ARRAY_SIZE"])
 
 inclinations    = [85.0, 90.0]        # degrees
 periods         = np.linspace(2.0, 100.0, 10)         # days
@@ -97,23 +153,31 @@ primary_mass    = 1.0
 n_times         = 20
 n_mesh_elements = int(os.environ["N_MESH_ELEMENTS"])
 
+rows = []
+for incl in inclinations:
+    for P in periods:
+        for q in qs:
+            for e in eccs:
+                rows.append([f"{incl:.4f}", f"{P:.4f}", q, e, primary_mass,
+                             n_times, n_mesh_elements])
+
+slice_rows = [r for i, r in enumerate(rows) if (i % array_size) == (array_index - 1)]
+
 with open(sys.argv[1], "w", newline="") as f:
     w = csv.writer(f)
     w.writerow(["inclination", "period", "q", "ecc", "primary_mass", "n_times",
                 "n_mesh_elements"])
-    for incl in inclinations:
-        for P in periods:
-            for q in qs:
-                for e in eccs:
-                    w.writerow([f"{incl:.4f}", f"{P:.4f}", q, e, primary_mass,
-                                n_times, n_mesh_elements])
+    w.writerows(slice_rows)
 PY
-    echo "Generated grid: ${GRID_CSV}"
+    echo "Generated slice: ${TASK_GRID_CSV} (element ${ARRAY_INDEX}/${ARRAY_SIZE})"
 fi
+
+GRID_CSV="${TASK_GRID_CSV}"
 
 NTASKS="$(( $(wc -l < "${GRID_CSV}") - 1 ))"
 echo "==============================================================="
 echo "Job:        ${PBS_JOBID}"
+echo "Array idx:  ${ARRAY_INDEX} / ${ARRAY_SIZE}"
 echo "Node:       $(hostname)"
 echo "CPUs:       ${PBS_NCPUS}"
 echo "Repo:       ${SPICE_REPO}"
@@ -125,12 +189,13 @@ echo "==============================================================="
 # Run
 # ---------------------------------------------------------------------------
 # Parallelism vs memory: each worker holds PHOEBE + JAX; peak RSS per worker can
-# reach tens of GB on hard grid points. Do NOT set --n-workers = PBS_NCPUS unless
-# you have measured a safe per-worker peak. Rule of thumb on a 400 GB node:
+# reach tens of GB on hard grid points. Each array element gets its own node
+# allocation, so size N_WORKERS to that element's mem, not the array total.
+# Rule of thumb on a 128 GB element:
 #   N_WORKERS ≈ (0.6 * mem_GB) / peak_RSS_GB_per_worker
-# Example: if `ps` shows peaks ~25 GB, use N_WORKERS≈9–12, not 104.
-# Override before qsub, e.g.  export N_WORKERS=12
-N_WORKERS="${N_WORKERS:-$(( PBS_NCPUS / 8 ))}"
+# Example: if `ps` shows peaks ~25 GB, use N_WORKERS≈3, not PBS_NCPUS.
+# Override before qsub, e.g.  export N_WORKERS=4
+N_WORKERS="${N_WORKERS:-$(( PBS_NCPUS / 4 ))}"
 if (( N_WORKERS < 1 )); then N_WORKERS=1; fi
 # Recycle workers so JAX/PHOEBE heap cannot grow without bound across thousands
 # of tasks (slower per task due to re-init). Default 15 when unset; set
@@ -144,7 +209,8 @@ if [[ -n "${MAX_TASKS_PER_CHILD}" ]]; then
 fi
 #
 # `set -e` above means a non-zero exit from python (i.e. a non-PHOEBE-convergence
-# error inside any worker) will skip the trailing "Done." line and fail the job.
+# error inside any worker) will skip the trailing "Done." line and fail this
+# array element. Other elements are unaffected.
 echo "Python workers: ${N_WORKERS}  (PBS_NCPUS=${PBS_NCPUS})"
 if ((${#MTPC_ARGS[@]})); then
     echo "maxtasksperchild: ${MAX_TASKS_PER_CHILD}"
@@ -156,10 +222,10 @@ if "${PYTHON_BIN}" "${SPICE_REPO}/tutorial/paper_results/check_phoebe_eclipses.p
     --n-workers   "${N_WORKERS}" \
     "${MTPC_ARGS[@]}" \
     --output_path "${OUTPUT_DIR}"; then
-    echo "Done. Outputs in ${OUTPUT_DIR}"
+    echo "Done (element ${ARRAY_INDEX}/${ARRAY_SIZE}). Outputs in ${OUTPUT_DIR}"
 else
     rc=$?
-    echo "ABORTED (rc=${rc}). Partial outputs preserved in ${OUTPUT_DIR}." >&2
+    echo "ABORTED element ${ARRAY_INDEX}/${ARRAY_SIZE} (rc=${rc}). Partial outputs preserved in ${OUTPUT_DIR}." >&2
     echo "Resubmit after the fix — already-completed pickles will be skipped." >&2
     exit "${rc}"
 fi


### PR DESCRIPTION
…TPUT_DIR

Run as a 10-element array (`#PBS -J 1-10`) so grid points are processed across many nodes concurrently. Each element generates its own round-robin slice CSV from the default sweep (or from a user-supplied master CSV) so no two elements duplicate work and difficulty bias is spread evenly.

Drop PBS_JOBID from the default OUTPUT_DIR in favor of a RUN_NAME-based path so resubmissions resume rather than starting a fresh directory; the Python script's per-pickle skip logic then deduplicates across submissions. Always regenerate the per-element slice so changing ARRAY_SIZE between runs doesn't leave stale partitions on disk.