### PR TITLE
Extend Cepheid grid builder with four emulator bundles and δ Cep rot/…

### DIFF
--- a/tutorial/paper_results/build_cepheid_grid.py
+++ b/tutorial/paper_results/build_cepheid_grid.py
@@ -3,26 +3,40 @@
 
 For each entry in the configured Cepheid grid this script:
 
-  1. Builds one :class:`IntensityLazyZarrInterpolator` and one
-     :class:`FluxLazyZarrInterpolator`. LD coefficients are bound per call at
-     synthesis time, so we don't rebuild emulators or bundles per coefficient.
-  2. Constructs two mesh bundles per Cepheid -- ``intensity`` (per-face mu) and
-     ``flux_no_ld`` -- using the Cepheid's stellar parameters and a Fourier-
-     decomposed radius pulsation template.
+  1. Loads up to four spectrum emulators -- ``IntensityLazyZarrInterpolator``
+     (zarr line intensity grid, mu-conditioned), ``FluxLazyZarrInterpolator``
+     (zarr flux grid, applies a linear LD law at call time), and two
+     pretrained aemu intensity bundles (HARPS-resolution and a small
+     iron-line bundle). LD coefficients are bound per call at synthesis
+     time, so we don't rebuild emulators or bundles per coefficient.
+  2. Constructs up to four mesh bundles per Cepheid -- one per emulator --
+     using the Cepheid's stellar parameters and a Fourier-decomposed radius
+     pulsation template. Each emulator gets its own bundle because the
+     mesh stores stellar parameters in the emulator's training order, which
+     differs across the four.
   3. Pushes phase-dependent Teff, logg and vmicro into every snapshot
      (vmicro from the Luck 2018 delta Cep fit; Teff/logg from SPIPS3).
-  4. Synthesises 5000-5020 Å spectra for ``with_ld`` plus a 20-point linear
-     LD coefficient sweep, all reusing the ``flux_no_ld`` bundle.
+     Modifier indices are looked up by name from each emulator's
+     ``stellar_parameter_names``; emulators that don't carry vmicro just
+     skip that modifier.
+  4. Synthesises 5000-5020 Å spectra for ``with_ld`` (zarr intensity bundle)
+     plus a 20-point linear LD coefficient sweep on the zarr flux bundle,
+     plus one variant per aemu bundle.
   5. Pickles ``<name>_bundles.pkl`` and ``<name>_spectra.pkl`` to ``--out-dir``.
 
 The default grid spans the classical-Cepheid period range (3-30 d) using the
 Bono et al. 2001 PR relation for radius and mass, and the Delta-Cep SPIPS3
-template for the pulsation shape and phase-resolved Teff/logg trends. Override
+template for the pulsation shape and phase-resolved Teff/logg trends. δ Cep
+appears twice — ``cep_DeltaCep`` (12 km/s rotation) and ``cep_DeltaCep_norot``
+— so rotating and non-rotating cases are built without a custom CSV. Override
 or extend the grid via ``--config CSV`` (see :func:`load_grid_csv`).
 
-Synthesis is the slow step (~1-2 min per variant on CPU; 21 variants, so
-~30-45 min per Cepheid). The script is restartable: existing per-Cepheid
-pickles in ``--out-dir`` are skipped unless ``--force`` is given.
+Synthesis is the slow step (~1-2 min per variant on CPU; 23 variants by
+default, so ~30-45 min per Cepheid). The script is restartable: existing
+per-Cepheid pickles in ``--out-dir`` are skipped unless ``--force`` is given.
+Pass ``--skip-aemu`` to drop the two aemu bundles (the
+``astro_emulators_toolkit`` extra is then optional) or ``--skip-zarr`` to
+drop the two zarr bundles.
 """
 from __future__ import annotations
 
@@ -34,7 +48,7 @@ import time
 import traceback
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional, Sequence
 
 # CPU-only on macOS, matches src/spice/__init__.py
 os.environ.setdefault("JAX_PLATFORMS", "cpu")
@@ -71,6 +85,18 @@ from cepheid_bundles import (  # noqa: E402  (sys.path patched above)
 LINE_INTERP_PATH = "/g/data/y89/mj8805/fe_regular_nlte_big.zarr"
 FLUX_INTERP_PATH = "/g/data/y89/mj8805/fe_nlte_flux_big.zarr/regular_synthesized_spectra.zarr"
 
+# Pretrained aemu (astro_emulators_toolkit) bundles. Both expose
+# ``IntensityPretrainedAemuSpectrumEmulator``. Defaults match
+# benchmarks/benchmark_spice_components.py.
+DEFAULT_HARPS_AEMU = "RozanskiT/TPayne-spice-harps"
+DEFAULT_IRON_AEMU  = "RozanskiT/TPayne-spice-small-random"
+
+# Bundle variant keys that this script knows how to build. Used by `--bundles`
+# / `--skip-aemu` / `--skip-zarr`. Order is the build order.
+ALL_BUNDLES = ("intensity", "flux_no_ld", "harps", "iron_line")
+ZARR_BUNDLES = ("intensity", "flux_no_ld")
+AEMU_BUNDLES = ("harps", "iron_line")
+
 INTENSITY_PARAMS = ["teff", "logg", "[Fe/H]", "vmicro", "[a/Fe]",
                     "[C/Fe]", "[N/Fe]", "[O/Fe]", "[r/Fe]", "[s/Fe]", "mu"]
 FLUX_PARAMS      = ["teff", "logg", "[Fe/H]", "vmicro", "[a/Fe]",
@@ -84,6 +110,9 @@ SOLAR_FLUX      = np.array([5777, 4.44, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
 LD_COEFFS = np.linspace(0.0, 1.0, 20)
 LD_FMT = ".3f"
 DEFAULT_PULSATION_FITS = HERE / "delta_cep.fits"
+
+# δ Cep projected rotation used in cepheid_grid.csv / cepheid_analysis.ipynb.
+DELTA_CEP_ROTATION_KMS = 12.0
 
 WL_MIN, WL_MAX = 5000.0, 5020.0
 WL_STEPS = 2000
@@ -135,18 +164,40 @@ class CepheidConfig:
         }
 
 
+def _delta_cep_configs() -> tuple[CepheidConfig, CepheidConfig]:
+    """δ Cep literature parameters, rotating and non-rotating (cepheid_grid.csv)."""
+    common = dict(
+        period=5.366265401100268,
+        radius=43.06,
+        mass=5.26,
+        teff=6562.0,
+        logg=1.883,
+        fe_h=0.06,
+    )
+    return (
+        CepheidConfig(name="cep_DeltaCep", rotation_velocity=DELTA_CEP_ROTATION_KMS, **common),
+        CepheidConfig(name="cep_DeltaCep_norot", rotation_velocity=0.0, **common),
+    )
+
+
 def default_grid() -> list[CepheidConfig]:
-    """A 5-star classical-Cepheid grid covering log P = 0.5–1.5.
+    """Six-entry classical-Cepheid grid covering log P = 0.5–1.5.
 
     Radius scales via Bono et al. 2001 (log R/R_sun = 0.748 log P + 1.10).
     Mass-period passes through Delta-Cep (M=5.26, P=5.366) with slope 0.4 in
     log-log, giving ~4-10 M_sun across P=3-30 d (consistent with pulsation-
     model masses). Teff drops along the IS toward longer period (rough fit
     to Madore & Freedman 1991); logg follows from M and R.
+
+    δ Cep is listed twice (``cep_DeltaCep`` at :data:`DELTA_CEP_ROTATION_KMS`
+    km/s and ``cep_DeltaCep_norot`` at 0 km/s); other periods are non-rotating.
     """
-    rows = []
+    rows: list[CepheidConfig] = []
     for p_days, teff in [(3.0, 6300), (5.366, 6562), (10.0, 5800),
                          (20.0, 5500), (30.0, 5300)]:
+        if p_days == 5.366:
+            rows.extend(_delta_cep_configs())
+            continue
         log_p = np.log10(p_days)
         radius = 10.0 ** (0.748 * log_p + 1.10)
         mass   = 10.0 ** (0.40 * log_p + 0.430)
@@ -158,13 +209,6 @@ def default_grid() -> list[CepheidConfig]:
             teff=float(teff), logg=float(logg),
             fe_h=0.0,
         ))
-    # Replace the P=5.366 entry with the actual Delta-Cep parameters used in
-    # the notebook so analysis-notebook compatibility is preserved.
-    rows[1] = CepheidConfig(
-        name="cep_DeltaCep", period=5.366265401100268,
-        radius=43.06, mass=5.26,
-        teff=6562.0, logg=1.883, fe_h=0.06,
-    )
     return rows
 
 
@@ -268,23 +312,80 @@ def make_phase_modifiers(pulsation_data: Table):
 # ---------------------------------------------------------------------------
 # Emulator setup (built once, shared across all Cepheids)
 # ---------------------------------------------------------------------------
-def build_emulators(intensity_path: str, flux_path: str):
-    """Build one intensity and one flux emulator, matching the notebook.
+def _load_aemu_intensity(name: str):
+    """Lazy-import + load an :class:`IntensityPretrainedAemuSpectrumEmulator`.
 
-    LD coefficients are passed per call to ``simulate_observed_flux`` at
-    synthesis time, so we don't need a separate flux emulator per coefficient.
+    Imported here (not at module top) so the script still imports when the
+    optional ``aemu`` extra is missing -- relevant when callers pass
+    ``--skip-aemu`` to build the two zarr bundles only.
     """
-    print(f"Loading intensity grid: {intensity_path}")
-    intensity = IntensityLazyZarrInterpolator(
-        intensity_path, params=INTENSITY_PARAMS, solar_parameters=SOLAR_INTENSITY,
-        sparse=True, in_memory=False,
+    from spice.spectrum.aemu_spectrum_emulator import (
+        IntensityPretrainedAemuSpectrumEmulator,
     )
-    print(f"Loading flux grid:      {flux_path}")
-    flux = FluxLazyZarrInterpolator(
-        flux_path, params=FLUX_PARAMS, solar_parameters=SOLAR_FLUX,
-        sparse=True, in_memory=False,
-    )
-    return intensity, flux
+    return IntensityPretrainedAemuSpectrumEmulator(name)
+
+
+def build_emulators(
+    intensity_path: str,
+    flux_path: str,
+    *,
+    harps_aemu: Optional[str] = DEFAULT_HARPS_AEMU,
+    iron_aemu: Optional[str] = DEFAULT_IRON_AEMU,
+    wanted: Sequence[str] = ALL_BUNDLES,
+) -> dict[str, Any]:
+    """Build the emulator backing each requested bundle variant.
+
+    Returns ``{bundle_name: emulator}`` for every key in ``wanted`` (subset of
+    :data:`ALL_BUNDLES`). LD coefficients for the ``flux_no_ld`` variant are
+    passed per call to ``simulate_observed_flux`` at synthesis time, so we
+    don't need a separate flux emulator per coefficient.
+    """
+    out: dict[str, Any] = {}
+    if "intensity" in wanted:
+        print(f"Loading intensity grid: {intensity_path}")
+        out["intensity"] = IntensityLazyZarrInterpolator(
+            intensity_path, params=INTENSITY_PARAMS, solar_parameters=SOLAR_INTENSITY,
+            sparse=True, in_memory=False,
+        )
+    if "flux_no_ld" in wanted:
+        print(f"Loading flux grid:      {flux_path}")
+        out["flux_no_ld"] = FluxLazyZarrInterpolator(
+            flux_path, params=FLUX_PARAMS, solar_parameters=SOLAR_FLUX,
+            sparse=True, in_memory=False,
+        )
+    if "harps" in wanted and harps_aemu is not None:
+        print(f"Loading HARPS aemu:     {harps_aemu}")
+        out["harps"] = _load_aemu_intensity(harps_aemu)
+    if "iron_line" in wanted and iron_aemu is not None:
+        print(f"Loading iron-line aemu: {iron_aemu}")
+        out["iron_line"] = _load_aemu_intensity(iron_aemu)
+    return out
+
+
+# Names of phase-dependent stellar parameters that the SPIPS3 / Luck-2018
+# templates produce. Mapped to bundle parameter indices via
+# ``_phase_modifiers_for`` -- only parameters that the emulator actually
+# carries get a modifier.
+PHASE_MODIFIER_NAMES = ("teff", "logg", "vmicro")
+
+
+def _phase_modifiers_for(emulator, teff_at, logg_at, vmicro_at):
+    """Build a ``[(param_index, fn), ...]`` modifier list for ``emulator``.
+
+    Looks up each phase-dependent parameter by name in the emulator's
+    ``stellar_parameter_names`` and skips any that are not present (e.g.
+    aemu bundles that don't carry vmicro).
+    """
+    name_to_fn = {"teff": teff_at, "logg": logg_at, "vmicro": vmicro_at}
+    names = list(getattr(emulator, "stellar_parameter_names", []))
+    if not names:
+        # Last-resort fallback: assume the canonical zarr ordering.
+        names = INTENSITY_PARAMS[:-1] if "intensity" in repr(type(emulator)) else FLUX_PARAMS
+    out = []
+    for n, fn in name_to_fn.items():
+        if n in names:
+            out.append((names.index(n), fn))
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -292,8 +393,7 @@ def build_emulators(intensity_path: str, flux_path: str):
 # ---------------------------------------------------------------------------
 def build_one(
     config: CepheidConfig,
-    intensity_emulator,
-    flux_emulator,
+    emulators: dict[str, Any],
     out_dir: Path,
     *,
     skip_spectra: bool = False,
@@ -305,6 +405,7 @@ def build_one(
     print(f"\n=== {config.name}  P={config.period:.4f} d  "
           f"R={config.radius:.2f} R_sun  M={config.mass:.2f} M_sun  "
           f"v_rot={config.rotation_velocity:.2f} km/s  n_vertices={n_mesh_used} ===")
+    print(f"  variants: {', '.join(emulators.keys())}")
 
     with fits.open(config.pulsation_fits, ignore_missing_simple=True) as hdul:
         pulsation_data = Table(hdul[2].data)
@@ -323,39 +424,32 @@ def build_one(
 
     timeseries = jnp.linspace(0, config.period, N_PHASES)
 
-    # 1) Build only two bundles — `intensity` (with mu) and `flux_no_ld`. The
-    # 20-point linear-LD sweep happens at synthesis time below by passing
-    # ld_coeffs to simulate_observed_flux, which avoids rebuilding the bundle
-    # per coefficient.
-    bundle_configs = {
-        "intensity":  (intensity_emulator,
-                       intensity_emulator.to_parameters(sp),
-                       "stellar_parameter_names"),
-        "flux_no_ld": (flux_emulator,
-                       flux_emulator.to_parameters(sp),
-                       "stellar_parameter_names"),
-    }
-
+    # 1) Build one bundle per emulator. Each emulator has its own parameter
+    # ordering; ``build_bundle`` reads ``stellar_parameter_names`` and stores
+    # parameters on the mesh in that emulator's order.
     bundles: dict[str, CepheidBundle] = {}
-    for name, (emul, params, attr) in bundle_configs.items():
+    for name, emul in emulators.items():
         print(f"  building {name}…")
         bundles[name] = build_bundle(
-            emul, params,
+            emul, emul.to_parameters(sp),
             fourier_params=fourier,
             period=config.period, timeseries=timeseries,
             n_mesh=n_mesh_used, radius=config.radius, mass=config.mass,
             rotation_velocity=config.rotation_velocity,
-            param_names_attr=attr, desc=f"  evaluating {name}",
+            param_names_attr="stellar_parameter_names",
+            desc=f"  evaluating {name}",
         )
 
-    # 2) Phase-dependent Teff, logg, and vmicro
-    #    Param indices: 0 = teff, 1 = logg, 3 = vmicro (same in INTENSITY_PARAMS
-    #    and FLUX_PARAMS — both schemes share the first ten stellar columns).
+    # 2) Phase-dependent Teff, logg, and vmicro. Modifier indices are looked
+    # up by name in each emulator's ``stellar_parameter_names``; aemu bundles
+    # that lack a particular parameter (e.g. vmicro) silently skip it.
     phases_per_snapshot = [(t % config.period) / config.period for t in timeseries]
     for name, bundle in bundles.items():
+        modifiers = _phase_modifiers_for(
+            emulators[name], teff_at, logg_at, vmicro_at,
+        )
         bundles[name] = apply_phase_params(
-            bundle, phases_per_snapshot,
-            modifiers=[(0, teff_at), (1, logg_at), (3, vmicro_at)],
+            bundle, phases_per_snapshot, modifiers=modifiers,
         )
 
     save_pickle(bundles, str(bundles_path))
@@ -365,25 +459,37 @@ def build_one(
         print("  (skip-spectra: leaving spectra unbuilt)")
         return
 
-    # 3) Spectrum synthesis. One `with_ld` variant on the intensity bundle
-    # plus N linear-LD variants that all reuse `flux_no_ld` and bind a
-    # different ld_coeffs at call time.
+    # 3) Spectrum synthesis. The intensity/aemu bundles each get a single
+    # variant; the zarr flux bundle additionally fans out into a 20-point
+    # linear-LD coefficient sweep (different ``ld_coeffs`` per call, no
+    # rebuild required).
     line_center = 0.5 * (WL_MIN + WL_MAX)
     line_width = 0.5 * (WL_MAX - WL_MIN)
 
-    spectrum_variants = [(
-        "with_ld",
-        intensity_emulator.intensity,
-        bundles["intensity"],
-        None,
-    )]
-    for c in LD_COEFFS:
+    spectrum_variants: list[tuple[str, Any, CepheidBundle, Optional[Any]]] = []
+    if "intensity" in bundles:
         spectrum_variants.append((
-            f"flux_linear_{c:{LD_FMT}}",
-            flux_emulator.intensity,
-            bundles["flux_no_ld"],
-            jnp.array([float(c), 0.0, 0.0, 0.0]),
+            "with_ld",
+            emulators["intensity"].intensity,
+            bundles["intensity"],
+            None,
         ))
+    if "flux_no_ld" in bundles:
+        for c in LD_COEFFS:
+            spectrum_variants.append((
+                f"flux_linear_{c:{LD_FMT}}",
+                emulators["flux_no_ld"].intensity,
+                bundles["flux_no_ld"],
+                jnp.array([float(c), 0.0, 0.0, 0.0]),
+            ))
+    for name in ("harps", "iron_line"):
+        if name in bundles:
+            spectrum_variants.append((
+                name,
+                emulators[name].intensity,
+                bundles[name],
+                None,
+            ))
 
     spectra: dict[str, dict[float, LineSpectra]] = {}
     for name, intensity_fn, bundle, ld_coeffs in spectrum_variants:
@@ -410,13 +516,29 @@ def parse_args():
     p.add_argument("--out-dir", type=Path, default=HERE / "cepheid_grid",
                    help="Directory for per-star pickles.")
     p.add_argument("--config", type=Path, default=None,
-                   help="CSV with custom Cepheid grid (default: built-in 5-star grid).")
+                   help="CSV with custom Cepheid grid (default: built-in 6-entry grid).")
     p.add_argument("--names", nargs="+", default=None,
                    help="Subset of grid names to build (default: all).")
     p.add_argument("--intensity-zarr", type=str, default=LINE_INTERP_PATH,
                    help=f"Intensity grid zarr path (default: {LINE_INTERP_PATH}).")
     p.add_argument("--flux-zarr", type=str, default=FLUX_INTERP_PATH,
                    help=f"Flux grid zarr path (default: {FLUX_INTERP_PATH}).")
+    p.add_argument("--harps-aemu", type=str, default=DEFAULT_HARPS_AEMU,
+                   help="HARPS aemu bundle: HF repo id or local bundle dir "
+                        f"(default: {DEFAULT_HARPS_AEMU}).")
+    p.add_argument("--iron-aemu", type=str, default=DEFAULT_IRON_AEMU,
+                   help="Iron-line aemu bundle: HF repo id or local bundle dir "
+                        f"(default: {DEFAULT_IRON_AEMU}).")
+    p.add_argument("--skip-aemu", action="store_true",
+                   help="Skip the HARPS and iron-line aemu bundles "
+                        "(useful when astro_emulators_toolkit isn't installed).")
+    p.add_argument("--skip-zarr", action="store_true",
+                   help="Skip the zarr intensity/flux bundles (only build the aemu ones).")
+    p.add_argument("--bundles", nargs="+", default=None,
+                   choices=list(ALL_BUNDLES),
+                   help="Explicit subset of bundle variants to build "
+                        f"(default: all of {list(ALL_BUNDLES)}; "
+                        "overrides --skip-aemu / --skip-zarr).")
     p.add_argument("--n-mesh", type=int, default=5000,
                    help="Icosphere mesh resolution.")
     p.add_argument("--force", action="store_true",
@@ -426,6 +548,20 @@ def parse_args():
     p.add_argument("--continue-on-error", action="store_true",
                    help="If a star fails, log and move on instead of aborting.")
     return p.parse_args()
+
+
+def _resolve_bundle_set(args) -> tuple[str, ...]:
+    """Combine ``--bundles`` / ``--skip-aemu`` / ``--skip-zarr`` into a final
+    ordered tuple of bundle keys to build."""
+    if args.bundles:
+        wanted = tuple(b for b in ALL_BUNDLES if b in set(args.bundles))
+    else:
+        wanted = ALL_BUNDLES
+    if args.skip_aemu:
+        wanted = tuple(b for b in wanted if b not in AEMU_BUNDLES)
+    if args.skip_zarr:
+        wanted = tuple(b for b in wanted if b not in ZARR_BUNDLES)
+    return wanted
 
 
 def main() -> int:
@@ -455,9 +591,18 @@ def main() -> int:
         print("Nothing to do.")
         return 0
 
+    wanted_bundles = _resolve_bundle_set(args)
+    if not wanted_bundles:
+        print("No bundle variants selected (check --bundles / --skip-aemu / --skip-zarr).",
+              file=sys.stderr)
+        return 1
+
     print(f"Will build {len(pending)} Cepheid(s) → {args.out_dir.resolve()}")
-    intensity_emulator, flux_emulator = build_emulators(
+    print(f"Bundle variants: {list(wanted_bundles)}")
+    emulators = build_emulators(
         args.intensity_zarr, args.flux_zarr,
+        harps_aemu=args.harps_aemu, iron_aemu=args.iron_aemu,
+        wanted=wanted_bundles,
     )
 
     failures = []
@@ -466,8 +611,7 @@ def main() -> int:
         star_t0 = time.perf_counter()
         try:
             build_one(
-                cfg, intensity_emulator, flux_emulator,
-                args.out_dir,
+                cfg, emulators, args.out_dir,
                 skip_spectra=args.skip_spectra,
                 n_mesh=args.n_mesh,
             )


### PR DESCRIPTION
…norot.

Add zarr intensity/flux, HARPS aemu, and iron-line aemu bundle variants with per-emulator phase modifiers; default grid now includes cep_DeltaCep (12 km/s) and cep_DeltaCep_norot.