### PR TITLE
PBS: disable cuDNN frontend to work around missing runtime-compiled e…

### DIFF
--- a/tutorial/paper_results/run_cepheid_ld_sweep.pbs
+++ b/tutorial/paper_results/run_cepheid_ld_sweep.pbs
@@ -80,7 +80,12 @@ module load python3/3.11.7    # nearest available; check `module avail python3`
 
 # JAX & BLAS thread parallelism — match what PBS gave us.
 export JAX_PLATFORMS=cpu
-export XLA_FLAGS="--xla_cpu_multi_thread_eigen=true intra_op_parallelism_threads=${PBS_NCPUS:-8}"
+# `--xla_gpu_enable_cudnn_frontend=false` is dormant here (CPU-only), but kept
+# so cloning this PBS to GPU doesn't trip CUDNN_STATUS_SUBLIBRARY_LOADING_FAILED
+# on Gadi nodes whose cuDNN 9 install is missing
+# libcudnn_engines_runtime_compiled.so.9 (seen on the tz_fornacis_spectra
+# macroturbulence convolution).
+export XLA_FLAGS="--xla_cpu_multi_thread_eigen=true intra_op_parallelism_threads=${PBS_NCPUS:-8} --xla_gpu_enable_cudnn_frontend=false"
 export OMP_NUM_THREADS=${PBS_NCPUS:-8}
 export MKL_NUM_THREADS=${PBS_NCPUS:-8}
 export OPENBLAS_NUM_THREADS=${PBS_NCPUS:-8}

--- a/tutorial/paper_results/tz_fornacis/tz_fornacis_spectra.pbs
+++ b/tutorial/paper_results/tz_fornacis/tz_fornacis_spectra.pbs
@@ -41,6 +41,11 @@ PYTHON_BIN="${PYTHON_BIN:-/scratch/y89/mj8805/miniforge/envs/astro/bin/python}"
 unset JAX_PLATFORMS
 export XLA_PYTHON_CLIENT_PREALLOCATE=false
 export XLA_PYTHON_CLIENT_ALLOCATOR=platform
+# Bypass cuDNN's runtime-compiled engines on Gadi GPU nodes whose cuDNN 9
+# install is missing libcudnn_engines_runtime_compiled.so.9 (otherwise the
+# macroturbulence Gaussian convolution in apply_spectral_resolution trips
+# CUDNN_STATUS_SUBLIBRARY_LOADING_FAILED).
+export XLA_FLAGS="${XLA_FLAGS:-} --xla_gpu_enable_cudnn_frontend=false"
 export TF_CPP_MIN_LOG_LEVEL=2
 export OMP_NUM_THREADS=${PBS_NCPUS:-12}
 export MKL_NUM_THREADS=${PBS_NCPUS:-12}


### PR DESCRIPTION
…ngines on Gadi.

cuDNN 9 on some Gadi GPU nodes is missing libcudnn_engines_runtime_compiled.so.9, which trips CUDNN_STATUS_SUBLIBRARY_LOADING_FAILED on the macroturbulence Gaussian convolution in tz_fornacis_spectra. Add --xla_gpu_enable_cudnn_frontend=false to XLA_FLAGS so XLA falls back to the legacy cuDNN dispatch that doesn't need the compiled-engines sublibrary; also add it (dormant) to run_cepheid_ld_sweep.pbs so a GPU clone of that script is protected too.