### PR TITLE
Fix Gadi cuDNN crash, atomic resume, and bundle-merge gating across p…

### DIFF
--- a/tutorial/paper_results/build_cepheid_grid.py
+++ b/tutorial/paper_results/build_cepheid_grid.py
@@ -618,15 +618,21 @@ def build_one(
     line_center = 0.5 * (WL_MIN + WL_MAX)
     line_width = 0.5 * (WL_MAX - WL_MIN)
 
+    # Gate each variant on BOTH the bundle existing AND the emulator being
+    # loaded in this invocation. ``bundles`` is post-merge with the on-disk
+    # pickle, so it can carry variants from earlier runs (e.g. ``intensity``
+    # / ``harps`` from the main grid build) whose emulators weren't requested
+    # this time. Their spectra remain on disk via the merge at the end of
+    # this function — we just don't try to re-synthesize them here.
     spectrum_variants: list[tuple[str, Any, CepheidBundle, Optional[Any]]] = []
-    if "intensity" in bundles:
+    if "intensity" in bundles and "intensity" in emulators:
         spectrum_variants.append((
             "with_ld",
             emulators["intensity"].intensity,
             bundles["intensity"],
             None,
         ))
-    if "flux_no_ld" in bundles:
+    if "flux_no_ld" in bundles and "flux_no_ld" in emulators:
         for c in LD_COEFFS:
             spectrum_variants.append((
                 f"flux_linear_{c:{LD_FMT}}",
@@ -634,7 +640,7 @@ def build_one(
                 bundles["flux_no_ld"],
                 jnp.array([float(c), 0.0, 0.0, 0.0]),
             ))
-    if "intensity_mu1" in bundles:
+    if "intensity_mu1" in bundles and "intensity_mu1" in emulators:
         # One adapter reused across the 20 coefficient calls so the
         # surrounding ``LdBoundIntensity`` hashes stably and jit only
         # recompiles for new coefficients.
@@ -647,7 +653,7 @@ def build_one(
                 jnp.array([float(c), 0.0, 0.0, 0.0]),
             ))
     for name in ("harps", "iron_line"):
-        if name in bundles:
+        if name in bundles and name in emulators:
             spectrum_variants.append((
                 name,
                 emulators[name].intensity,

--- a/tutorial/paper_results/check_phoebe_eclipses.py
+++ b/tutorial/paper_results/check_phoebe_eclipses.py
@@ -41,6 +41,7 @@ if mp.get_start_method(allow_none=True) is None:
 import argparse
 import csv
 import gc
+import os
 import pickle
 import sys
 import time
@@ -265,7 +266,13 @@ def run_one(inclination, period, q, ecc, n_times, primary_mass, n_mesh_elements,
         bol_lum.append(AB_passband_luminosity(bol, vws, spec1[:, 0] + spec2[:, 0]))
     bol_lum = np.array(bol_lum)
 
-    with open(out_pkl, 'wb') as f:
+    # Atomic write so a SIGKILL / node crash / OOM mid-dump can never leave a
+    # truncated `.pkl` behind that the resume logic would then mistake for a
+    # completed task (`out_pkl.exists()` is the skip predicate at the top of
+    # this function). The tmp filename includes pid so concurrent workers
+    # producing different out_pkls can't collide on the tmp slot either.
+    out_pkl_tmp = out_pkl.with_name(f"{out_pkl.name}.tmp.{os.getpid()}")
+    with open(out_pkl_tmp, 'wb') as f:
         pickle.dump({
             'phoebe_binary': b,
             'spice_body1': pb1,
@@ -283,6 +290,9 @@ def run_one(inclination, period, q, ecc, n_times, primary_mass, n_mesh_elements,
             'ecc': ecc,
             'n_mesh_elements': n_mesh_elements,
         }, f)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(out_pkl_tmp, out_pkl)
 
     # Bound JAX cache + Python heap growth across many tasks per worker
     gc.collect()

--- a/tutorial/paper_results/run_cepheid_ld_sweep.pbs
+++ b/tutorial/paper_results/run_cepheid_ld_sweep.pbs
@@ -22,14 +22,15 @@
 #  preserved, and `intensity_mu1` + `intensity_mu1_linear_<u>` are added.
 #
 #  USAGE
-#    cd tutorial/paper_results
+#    cd <spice repo root>
 #
 #    # Full CSV (6 Cepheids, indices 0–5):
-#    qsub -J 0-$(( $(wc -l < cepheid_grid.csv) - 2 )) run_cepheid_ld_sweep.pbs
+#    qsub -J 0-$(( $(wc -l < tutorial/paper_results/cepheid_grid.csv) - 2 )) \
+#        tutorial/paper_results/run_cepheid_ld_sweep.pbs
 #
 #    # δ Cep rotating + non-rot only (CSV rows 1–2):
 #    qsub -J 1-2 -v OUT_DIR=/home/100/mj8805/scr_y89/spice/cepheid_grid \
-#        run_cepheid_ld_sweep.pbs
+#        tutorial/paper_results/run_cepheid_ld_sweep.pbs
 #
 #    # If LD sweep was written elsewhere, merge once on a login node:
 #    python merge_cepheid_pickles.py --dst .../cepheid_grid --src .../cepheid_ld_sweep \
@@ -40,24 +41,26 @@
 #            (add `--force` in the python invocation to rebuild).
 #
 #  WALLTIME SIZING
-#    Synthesis is ~1-2 min per LD variant × 20 variants ≈ 25-45 min per
-#    Cepheid, plus ~3 min for the intensity zarr emulator load and bundle
-#    build. 04:00:00 covers it with margin; bump if you increase
+#    Synthesis on one V100 is ~30-60 s per LD variant × 20 variants ≈ 10-20 min
+#    per Cepheid, plus ~3 min for the intensity zarr emulator load and bundle
+#    build. 10:00:00 covers it with generous margin; bump if you increase
 #    LD_COEFFS or WL_STEPS in build_cepheid_grid.py.
 #============================================================================
 
-#PBS -P mk27
-#PBS -q rsaa
-#PBS -l walltime=04:00:00
-#PBS -l ncpus=8
-#PBS -l mem=32GB
-#PBS -l jobfs=50GB
+#PBS -P dg97
+#PBS -q gpursaa
+#PBS -l walltime=10:00:00
+#PBS -l ncpus=14
+#PBS -l ngpus=1
+#PBS -l mem=200GB
+#PBS -l jobfs=200GB
 #PBS -l storage=scratch/y89+gdata/y89
 #PBS -l wd
 #PBS -J 0-5
 #PBS -N cepheid_ld_sweep
+#PBS -r y
 #PBS -j oe
-#PBS -m a
+#PBS -m bae
 #PBS -M maja.jablonska@anu.edu.au
 
 set -euo pipefail
@@ -77,15 +80,13 @@ mapfile -t GRID_NAMES < <(tail -n +2 "$CONFIG" | cut -d',' -f1 | sed '/^$/d')
 # ---------------------------------------------------------------------------
 module purge
 module load python3/3.11.7    # nearest available; check `module avail python3`
+module load cuda/12.9.0
+module load cudnn/9.5.0-cuda12
 
-# JAX & BLAS thread parallelism — match what PBS gave us.
-export JAX_PLATFORMS=cpu
-# `--xla_gpu_enable_cudnn_frontend=false` is dormant here (CPU-only), but kept
-# so cloning this PBS to GPU doesn't trip CUDNN_STATUS_SUBLIBRARY_LOADING_FAILED
-# on Gadi nodes whose cuDNN 9 install is missing
-# libcudnn_engines_runtime_compiled.so.9 (seen on the tz_fornacis_spectra
-# macroturbulence convolution).
-export XLA_FLAGS="--xla_cpu_multi_thread_eigen=true intra_op_parallelism_threads=${PBS_NCPUS:-8} --xla_gpu_enable_cudnn_frontend=false"
+# JAX & BLAS thread parallelism — match what PBS gave us. The XLA flags only
+# affect CPU-side ops (host setup, small kernels); JAX itself runs on cuda.
+export JAX_PLATFORMS=cuda
+export XLA_FLAGS="--xla_cpu_multi_thread_eigen=true intra_op_parallelism_threads=${PBS_NCPUS:-8}"
 export OMP_NUM_THREADS=${PBS_NCPUS:-8}
 export MKL_NUM_THREADS=${PBS_NCPUS:-8}
 export OPENBLAS_NUM_THREADS=${PBS_NCPUS:-8}
@@ -116,10 +117,10 @@ cd "$PBS_O_WORKDIR"
 
 # Same directory as the main grid build so pickles merge (see build_cepheid_grid.py).
 OUT_DIR="${OUT_DIR:-$PBS_O_WORKDIR/cepheid_grid}"
-INTENSITY_ZARR="${INTENSITY_ZARR:-/g/data/y89/mj8805/fe_regular_nlte_big.zarr}"
+INTENSITY_ZARR="${INTENSITY_ZARR:-/g/data/y89/mj8805/PAPER/regular_fe.zarr}"
 mkdir -p "$OUT_DIR"
 
-"${PYTHON_BIN}" -u build_cepheid_grid.py \
+"${PYTHON_BIN}" -u tutorial/paper_results/build_cepheid_grid.py \
     --config "$CONFIG" \
     --names "$NAME" \
     --out-dir "$OUT_DIR" \

--- a/tutorial/paper_results/tz_fornacis/tz_fornacis_spectra.pbs
+++ b/tutorial/paper_results/tz_fornacis/tz_fornacis_spectra.pbs
@@ -41,11 +41,6 @@ PYTHON_BIN="${PYTHON_BIN:-/scratch/y89/mj8805/miniforge/envs/astro/bin/python}"
 unset JAX_PLATFORMS
 export XLA_PYTHON_CLIENT_PREALLOCATE=false
 export XLA_PYTHON_CLIENT_ALLOCATOR=platform
-# Bypass cuDNN's runtime-compiled engines on Gadi GPU nodes whose cuDNN 9
-# install is missing libcudnn_engines_runtime_compiled.so.9 (otherwise the
-# macroturbulence Gaussian convolution in apply_spectral_resolution trips
-# CUDNN_STATUS_SUBLIBRARY_LOADING_FAILED).
-export XLA_FLAGS="${XLA_FLAGS:-} --xla_gpu_enable_cudnn_frontend=false"
 export TF_CPP_MIN_LOG_LEVEL=2
 export OMP_NUM_THREADS=${PBS_NCPUS:-12}
 export MKL_NUM_THREADS=${PBS_NCPUS:-12}

--- a/tutorial/paper_results/tz_fornacis/tz_fornacis_spectra.py
+++ b/tutorial/paper_results/tz_fornacis/tz_fornacis_spectra.py
@@ -276,10 +276,20 @@ def _apply_macroturbulence(spectra, log_vws, vmacro_kms):
     if vmacro_kms <= 0.0:
         return spectra
     R_macro = _C_KMS / vmacro_kms
+    # Pin the 1-D Gaussian convolution to CPU: it routes through
+    # jax.lax.conv_general_dilated, which dispatches to cuDNN on GPU, and some
+    # Gadi cuDNN 9 installs are missing libcudnn_engines_runtime_compiled.so.9
+    # (CUDNN_STATUS_SUBLIBRARY_LOADING_FAILED). The op is tiny — there's no
+    # GPU win to fight for — and forcing it to CPU avoids cuDNN entirely.
+    cpu = jax.devices("cpu")[0]
+    log_vws_cpu = jax.device_put(log_vws, cpu)
     out = []
     for s in spectra:
-        line = apply_spectral_resolution(log_vws, jnp.asarray(s[:, 0]), R_macro)
-        cont = apply_spectral_resolution(log_vws, jnp.asarray(s[:, 1]), R_macro)
+        s0_cpu = jax.device_put(jnp.asarray(s[:, 0]), cpu)
+        s1_cpu = jax.device_put(jnp.asarray(s[:, 1]), cpu)
+        with jax.default_device(cpu):
+            line = apply_spectral_resolution(log_vws_cpu, s0_cpu, R_macro)
+            cont = apply_spectral_resolution(log_vws_cpu, s1_cpu, R_macro)
         out.append(np.stack([np.asarray(line), np.asarray(cont)], axis=-1))
     return np.asarray(out)
 


### PR DESCRIPTION
…aper-results scripts.

- tz_fornacis_spectra.py: pin _apply_macroturbulence's 1-D Gaussian convolution to CPU. jax.lax.conv_general_dilated dispatches to cuDNN on GPU, and some Gadi cuDNN 9 nodes are missing libcudnn_engines_runtime_compiled.so.9 (CUDNN_STATUS_SUBLIBRARY_LOADING_FAILED). The op is tiny so the host round-trip is free.
- tz_fornacis_spectra.pbs / run_cepheid_ld_sweep.pbs: drop --xla_gpu_enable_cudnn_frontend=false — it's unknown to this XLA build and aborts at flag-parse time (F-level).
- run_cepheid_ld_sweep.pbs: switch to gpursaa GPU queue (dg97, ngpus=1, 14 cpus, 200 GB mem/jobfs, 10 h walltime, restartable), load cuda/12.9.0 + cudnn/9.5.0-cuda12, JAX_PLATFORMS=cuda, point at the new PAPER/regular_fe.zarr, and qualify the python script path so submission happens from the repo root.
- build_cepheid_grid.py: gate each spectrum variant on its emulator being loaded *and* the bundle existing. Bundles are merged with the on-disk pickle, so an LD-only re-run that asks for --bundles intensity_mu1 was hitting KeyError('intensity') on emulators["intensity"] when a previous main-grid run had already left an intensity bundle on disk. Variants whose emulators aren't loaded this invocation now keep their existing spectra entries untouched via the spectra-pickle merge.
- check_phoebe_eclipses.py: write each per-task pickle atomically (tmp file + fsync + os.replace). The resume logic skips on out_pkl.exists(); without atomic writes, a SIGKILL / OOM / node crash mid-dump could leave a truncated .pkl that future runs would treat as complete and break downstream loaders.