### PR TITLE
Record spherical/plane-parallel geometry provenance in spectral grids

### DIFF
--- a/src/spice/spectrum/generate_zarr_index.py
+++ b/src/spice/spectrum/generate_zarr_index.py
@@ -1,3 +1,21 @@
+"""Build the ``index.parquet`` that a zarr spectral grid needs for axis lookup.
+
+Besides the stellar-parameter columns (and an optional ``mu`` column), the index
+can carry a ``geometry`` provenance column recording whether each grid node was
+synthesised in ``spherical`` or ``plane_parallel`` radiative-transfer geometry.
+MARCS/Korg compute giants (low ``logg``) in spherical symmetry and dwarfs (high
+``logg``) plane-parallel, so this records *which* was used per node rather than
+silently re-deriving it later. Geometry is provenance only -- it is never an
+interpolation axis (a categorical cannot be interpolated), so it rides along in
+the parquet, is ignored by the grid index, and is exposed as
+``LazyZarrInterpolator.geometry`` for callers that want to detect when a query
+straddles the plane-parallel/spherical boundary.
+
+The source of truth is a ``geometry`` array in the store (written by the grid
+producer, one label per row). When absent it can be derived from ``logg`` via
+``--geometry-from-logg`` as a heuristic fallback.
+"""
+
 import argparse
 from pathlib import Path
 
@@ -6,6 +24,22 @@ import zarr
 
 
 REQUIRED_GRID_ARRAYS = frozenset({"flux", "continuum", "wavelength", "params"})
+
+# Canonical labels for a grid node's radiative-transfer geometry, stored as
+# provenance in the index (and optionally as a ``geometry`` array in the store).
+PLANE_PARALLEL = "plane_parallel"
+SPHERICAL = "spherical"
+
+# Integer codes tolerated in a numeric ``geometry`` array (0 -> PP, 1 -> sph).
+_GEOMETRY_CODES = {0: PLANE_PARALLEL, 1: SPHERICAL}
+
+# Column aliases recognised when deriving geometry from surface gravity.
+_LOGG_ALIASES = ("logg", "log_g", "log g", "log_gs", "surface_gravity")
+
+# Default logg below which a node is labelled spherical when deriving geometry
+# from gravity. The targeted grids use logg < 3 -> spherical; MARCS' own
+# standard boundary is ~3.5. Overridable on the CLI.
+DEFAULT_SPHERICAL_LOGG_THRESHOLD = 3.0
 
 
 def resolve_grid_group(store, store_path):
@@ -49,7 +83,7 @@ def _get_polars():
     return pl
 
 
-def build_index_frame(params, param_names, mu_values=None):
+def build_index_frame(params, param_names, mu_values=None, geometry=None):
     """Build a polars DataFrame index from a params array.
 
     Parameters
@@ -62,6 +96,10 @@ def build_index_frame(params, param_names, mu_values=None):
     mu_values : array-like or None
         Optional 1-D array of mu values.  When provided it is included as the
         ``"mu"`` column regardless of whether ``"mu"`` appears in *param_names*.
+    geometry : sequence[str] or None
+        Optional per-row radiative-transfer geometry labels (e.g.
+        ``"spherical"`` / ``"plane_parallel"``). When provided it is added as a
+        ``"geometry"`` provenance column. It is not a grid axis.
     """
     params = np.asarray(params)
     if params.ndim != 2:
@@ -92,6 +130,14 @@ def build_index_frame(params, param_names, mu_values=None):
             )
         columns["mu"] = mu_values
 
+    if geometry is not None:
+        geometry = list(geometry)
+        if len(geometry) != params.shape[0]:
+            raise ValueError(
+                f"'geometry' length ({len(geometry)}) does not match params rows ({params.shape[0]})."
+            )
+        columns["geometry"] = geometry
+
     return _get_polars().DataFrame(columns)
 
 
@@ -119,7 +165,79 @@ def _load_mu_from_zarr(group, params, param_names, store_path):
     )
 
 
-def build_index_frame_from_zarr(store_path, include_mu=True):
+def geometry_labels_from_logg(logg, threshold=DEFAULT_SPHERICAL_LOGG_THRESHOLD):
+    """Heuristically label nodes ``spherical`` below ``threshold`` else
+    ``plane_parallel``, from surface gravity. Exposed so grid producers can
+    build a ``geometry`` array consistent with the index convention."""
+    return [SPHERICAL if float(g) < threshold else PLANE_PARALLEL
+            for g in np.asarray(logg).reshape(-1)]
+
+
+def _decode_geometry_array(values):
+    """Normalise a raw ``geometry`` array into a list of string labels.
+
+    String/bytes entries are passed through verbatim (only decoded), preserving
+    whatever the producer wrote; integer codes are mapped via
+    :data:`_GEOMETRY_CODES` (0 -> plane_parallel, 1 -> spherical).
+    """
+    labels = []
+    for value in np.asarray(values).reshape(-1):
+        if hasattr(value, "decode"):
+            labels.append(value.decode())
+        elif isinstance(value, str):
+            labels.append(str(value))
+        else:
+            code = int(value)
+            if code not in _GEOMETRY_CODES:
+                raise ValueError(
+                    f"Unrecognised integer geometry code {code!r}; expected one "
+                    f"of {sorted(_GEOMETRY_CODES)} ({_GEOMETRY_CODES})."
+                )
+            labels.append(_GEOMETRY_CODES[code])
+    return labels
+
+
+def _derive_geometry_from_logg(params, param_names, threshold):
+    lowered = {name.lower(): idx for idx, name in enumerate(param_names)}
+    logg_idx = next((lowered[a] for a in _LOGG_ALIASES if a in lowered), None)
+    if logg_idx is None:
+        raise KeyError(
+            "Cannot derive geometry from gravity: no logg-like column in "
+            f"param_names {param_names} (looked for {list(_LOGG_ALIASES)})."
+        )
+    return geometry_labels_from_logg(np.asarray(params)[:, logg_idx], threshold)
+
+
+def _load_geometry_from_zarr(group, params, param_names, store_path,
+                             geometry_from_logg=None):
+    """Return per-row geometry labels, or ``None`` when unavailable.
+
+    Priority: an explicit ``geometry`` array in the store (the producer's source
+    of truth) over derivation from ``logg`` (a heuristic, only when
+    ``geometry_from_logg`` is a threshold) over ``None`` (geometry is optional
+    provenance, so its absence is not an error).
+    """
+    n_rows = np.asarray(params).shape[0]
+    if "geometry" in group:
+        raw = np.asarray(group["geometry"][:])
+        if raw.ndim == 2 and raw.shape[1] == 1:
+            raw = raw[:, 0]
+        if raw.ndim != 1:
+            raise ValueError(f"Expected 'geometry' to be 1D, got shape {raw.shape}.")
+        if raw.shape[0] != n_rows:
+            raise ValueError(
+                f"'geometry' length ({raw.shape[0]}) does not match params rows ({n_rows})."
+            )
+        return _decode_geometry_array(raw)
+
+    if geometry_from_logg is not None:
+        return _derive_geometry_from_logg(params, param_names, geometry_from_logg)
+
+    return None
+
+
+def build_index_frame_from_zarr(store_path, include_mu=True,
+                                include_geometry=True, geometry_from_logg=None):
     store_path = Path(store_path).expanduser().resolve()
     root = zarr.open(str(store_path), mode="r")
     if not hasattr(root, "array_keys"):
@@ -138,7 +256,15 @@ def build_index_frame_from_zarr(store_path, include_mu=True):
     if include_mu:
         mu_values = _load_mu_from_zarr(group, params, param_names, store_path)
 
-    return build_index_frame(params, param_names, mu_values=mu_values)
+    geometry = None
+    if include_geometry:
+        geometry = _load_geometry_from_zarr(
+            group, params, param_names, store_path,
+            geometry_from_logg=geometry_from_logg,
+        )
+
+    return build_index_frame(params, param_names, mu_values=mu_values,
+                             geometry=geometry)
 
 
 def write_index_parquet(
@@ -146,6 +272,8 @@ def write_index_parquet(
     output_path=None,
     compression="zstd",
     include_mu=True,
+    include_geometry=True,
+    geometry_from_logg=None,
 ):
     store_path = Path(store_path).expanduser().resolve()
     if output_path is None:
@@ -153,7 +281,10 @@ def write_index_parquet(
     output_path = Path(output_path).expanduser().resolve()
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    frame = build_index_frame_from_zarr(store_path, include_mu=include_mu)
+    frame = build_index_frame_from_zarr(
+        store_path, include_mu=include_mu,
+        include_geometry=include_geometry, geometry_from_logg=geometry_from_logg,
+    )
     frame.write_parquet(output_path, compression=compression)
     return output_path
 
@@ -188,6 +319,36 @@ def parse_args():
         help="Exclude the `mu` column from the generated index.",
     )
     parser.set_defaults(include_mu=True)
+
+    geom_group = parser.add_mutually_exclusive_group()
+    geom_group.add_argument(
+        "--include-geometry",
+        dest="include_geometry",
+        action="store_true",
+        help="Record per-node radiative-transfer geometry (spherical / "
+             "plane_parallel) from the store's `geometry` array when present. "
+             "Provenance only; never used as an interpolation axis.",
+    )
+    geom_group.add_argument(
+        "--exclude-geometry",
+        dest="include_geometry",
+        action="store_false",
+        help="Do not write a `geometry` provenance column.",
+    )
+    parser.set_defaults(include_geometry=True)
+    parser.add_argument(
+        "--geometry-from-logg",
+        dest="geometry_from_logg",
+        nargs="?",
+        type=float,
+        const=DEFAULT_SPHERICAL_LOGG_THRESHOLD,
+        default=None,
+        metavar="THRESHOLD",
+        help="When the store has no `geometry` array, derive it from surface "
+             "gravity: nodes with logg below THRESHOLD (default "
+             f"{DEFAULT_SPHERICAL_LOGG_THRESHOLD} when the flag is given) are "
+             "labelled spherical. Heuristic; prefer a stored `geometry` array.",
+    )
     return parser.parse_args()
 
 
@@ -198,6 +359,8 @@ def main():
         output_path=args.output_path,
         compression=args.compression,
         include_mu=args.include_mu,
+        include_geometry=args.include_geometry,
+        geometry_from_logg=args.geometry_from_logg,
     )
     print(output_path)
 

--- a/src/spice/spectrum/lazy_zarr_interpolator.py
+++ b/src/spice/spectrum/lazy_zarr_interpolator.py
@@ -533,6 +533,14 @@ class LazyZarrInterpolator(SpectrumEmulator[ArrayLike]):
                     f"(use --exclude-mu if the grid has no mu axis)."
                 )
             df = pd.read_parquet(index_path)
+            # Optional per-node geometry provenance (spherical / plane_parallel),
+            # row_idx-ordered, or None for grids whose index predates it. It is
+            # never an interpolation axis -- expose it so callers can tell when a
+            # query straddles the plane-parallel/spherical boundary.
+            self.geometry = (
+                df.sort_values("row_idx")["geometry"].to_numpy()
+                if "geometry" in df.columns else None
+            )
             if sparse:
                 self.grid_index = SparseGridIndex.from_dataframe(df, columns=params, device=device)
             else:

--- a/tests/test_generate_zarr_index_geometry.py
+++ b/tests/test_generate_zarr_index_geometry.py
@@ -1,0 +1,160 @@
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import zarr
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "spice"
+    / "spectrum"
+    / "generate_zarr_index.py"
+)
+MODULE_SPEC = importlib.util.spec_from_file_location("generate_zarr_index", MODULE_PATH)
+generate_zarr_index = importlib.util.module_from_spec(MODULE_SPEC)
+assert MODULE_SPEC.loader is not None
+MODULE_SPEC.loader.exec_module(generate_zarr_index)
+
+build_index_frame_from_zarr = generate_zarr_index.build_index_frame_from_zarr
+geometry_labels_from_logg = generate_zarr_index.geometry_labels_from_logg
+PLANE_PARALLEL = generate_zarr_index.PLANE_PARALLEL
+SPHERICAL = generate_zarr_index.SPHERICAL
+
+
+class DummyFrame:
+    def __init__(self, columns):
+        self.columns = columns
+
+
+def _fake_polars():
+    return SimpleNamespace(DataFrame=DummyFrame)
+
+
+def _write_grid_store(tmp_path, params, param_names, geometry=None):
+    store_path = tmp_path / "grid.zarr"
+    group = zarr.open_group(str(store_path), mode="w")
+    group.create_dataset("flux", data=np.ones((params.shape[0], 3)))
+    group.create_dataset("continuum", data=np.ones((params.shape[0], 3)))
+    group.create_dataset("wavelength", data=np.linspace(5000.0, 5002.0, 3))
+    group.create_dataset("params", data=np.asarray(params))
+    group.create_dataset("param_names", data=np.asarray(param_names, dtype="S"))
+    if geometry is not None:
+        group.create_dataset("geometry", data=np.asarray(geometry))
+    return store_path
+
+
+def test_geometry_string_array_is_recorded_verbatim(tmp_path, monkeypatch):
+    monkeypatch.setattr(generate_zarr_index, "_get_polars", _fake_polars)
+    store_path = _write_grid_store(
+        tmp_path,
+        params=np.array([[5000.0, 4.4], [4500.0, 1.5]]),
+        param_names=["teff", "logg"],
+        geometry=np.asarray([PLANE_PARALLEL, SPHERICAL], dtype="S"),
+    )
+
+    frame = build_index_frame_from_zarr(store_path)
+
+    assert list(frame.columns["geometry"]) == [PLANE_PARALLEL, SPHERICAL]
+
+
+def test_geometry_integer_codes_are_mapped(tmp_path, monkeypatch):
+    monkeypatch.setattr(generate_zarr_index, "_get_polars", _fake_polars)
+    store_path = _write_grid_store(
+        tmp_path,
+        params=np.array([[5000.0, 4.4], [4500.0, 1.5]]),
+        param_names=["teff", "logg"],
+        geometry=np.array([0, 1]),  # 0 -> plane_parallel, 1 -> spherical
+    )
+
+    frame = build_index_frame_from_zarr(store_path)
+
+    assert list(frame.columns["geometry"]) == [PLANE_PARALLEL, SPHERICAL]
+
+
+def test_geometry_absent_omits_column(tmp_path, monkeypatch):
+    monkeypatch.setattr(generate_zarr_index, "_get_polars", _fake_polars)
+    store_path = _write_grid_store(
+        tmp_path,
+        params=np.array([[5000.0, 4.4], [4500.0, 1.5]]),
+        param_names=["teff", "logg"],
+    )
+
+    frame = build_index_frame_from_zarr(store_path)
+
+    assert "geometry" not in frame.columns
+
+
+def test_geometry_derived_from_logg_when_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(generate_zarr_index, "_get_polars", _fake_polars)
+    store_path = _write_grid_store(
+        tmp_path,
+        params=np.array([[5000.0, 4.4], [4500.0, 1.5]]),
+        param_names=["teff", "logg"],
+    )
+
+    frame = build_index_frame_from_zarr(store_path, geometry_from_logg=3.0)
+
+    assert list(frame.columns["geometry"]) == [PLANE_PARALLEL, SPHERICAL]
+
+
+def test_stored_geometry_wins_over_logg_derivation(tmp_path, monkeypatch):
+    monkeypatch.setattr(generate_zarr_index, "_get_polars", _fake_polars)
+    # Stored labels intentionally disagree with what logg<3 would derive.
+    store_path = _write_grid_store(
+        tmp_path,
+        params=np.array([[5000.0, 4.4], [4500.0, 1.5]]),
+        param_names=["teff", "logg"],
+        geometry=np.asarray([SPHERICAL, PLANE_PARALLEL], dtype="S"),
+    )
+
+    frame = build_index_frame_from_zarr(store_path, geometry_from_logg=3.0)
+
+    assert list(frame.columns["geometry"]) == [SPHERICAL, PLANE_PARALLEL]
+
+
+def test_exclude_geometry_drops_column_even_when_stored(tmp_path, monkeypatch):
+    monkeypatch.setattr(generate_zarr_index, "_get_polars", _fake_polars)
+    store_path = _write_grid_store(
+        tmp_path,
+        params=np.array([[5000.0, 4.4], [4500.0, 1.5]]),
+        param_names=["teff", "logg"],
+        geometry=np.asarray([PLANE_PARALLEL, SPHERICAL], dtype="S"),
+    )
+
+    frame = build_index_frame_from_zarr(store_path, include_geometry=False)
+
+    assert "geometry" not in frame.columns
+
+
+def test_geometry_rejects_mismatched_length(tmp_path, monkeypatch):
+    monkeypatch.setattr(generate_zarr_index, "_get_polars", _fake_polars)
+    store_path = _write_grid_store(
+        tmp_path,
+        params=np.array([[5000.0, 4.4], [4500.0, 1.5]]),
+        param_names=["teff", "logg"],
+        geometry=np.asarray([SPHERICAL], dtype="S"),
+    )
+
+    with pytest.raises(ValueError, match="geometry"):
+        build_index_frame_from_zarr(store_path)
+
+
+def test_geometry_from_logg_without_logg_column_raises(tmp_path, monkeypatch):
+    monkeypatch.setattr(generate_zarr_index, "_get_polars", _fake_polars)
+    store_path = _write_grid_store(
+        tmp_path,
+        params=np.array([[5000.0, 0.25], [4500.0, 0.75]]),
+        param_names=["teff", "mu"],
+    )
+
+    with pytest.raises(KeyError, match="logg"):
+        build_index_frame_from_zarr(store_path, geometry_from_logg=3.0)
+
+
+def test_geometry_labels_from_logg_threshold():
+    labels = geometry_labels_from_logg([4.5, 3.0, 2.9, 0.0], threshold=3.0)
+    # threshold is strict: logg < 3 -> spherical, logg >= 3 -> plane_parallel.
+    assert labels == [PLANE_PARALLEL, PLANE_PARALLEL, SPHERICAL, SPHERICAL]


### PR DESCRIPTION
## Summary

Low-logg (giant) atmospheres are synthesised in **spherical** geometry and dwarfs **plane-parallel**. This records *which* geometry was used per grid node, carried alongside the spectra so it isn't silently lost.

- **`generate_zarr_index.py`**: reads an optional per-row `geometry` array from the store into `index.parquet` (strings kept verbatim, int codes `0 → plane_parallel` / `1 → spherical`), mirroring the existing `mu_selected` path. Adds a `--geometry-from-logg [THRESHOLD]` heuristic fallback (default `3.0`, matching the grid's "logg < 3 → spherical" convention; MARCS' own boundary is ~3.5) and `--include/--exclude-geometry` flags. Public `geometry_labels_from_logg()` so grid producers can emit a consistent array.
- **`LazyZarrInterpolator.geometry`**: row-ordered labels (or `None` for grids whose index predates this); inherited by the `Intensity`/`Flux` subclasses.

**Geometry is provenance only — never an interpolation axis** (a categorical cannot be interpolated). It rides in the parquet, is ignored by `SparseGridIndex.from_dataframe` (which only reads `columns=params`), so it has **zero effect on lookups**. What it enables: detecting when an interpolation query straddles the plane-parallel/spherical boundary.

Source-of-truth priority: a stored `geometry` array → logg-derived heuristic → omitted (absence is not an error, unlike `mu`). The one external piece is that the grid producer (Korg/Julia assembly step) should emit a `geometry` array, one label per row.

## Tests

`tests/test_generate_zarr_index_geometry.py` (9 tests, mirroring the `mu_selected` suite). Like the rest of the `test_generate_zarr_index*` family, the fixtures target the CI zarr (v2); they don't run under the zarr v3 present in some local envs. All logic was additionally verified by direct calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)