### PR TITLE
Docs: fix Blackbody import source, filter names, and typos

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,10 +24,10 @@ This approach allows SPICE to accurately model stars with inhomogeneous surfaces
 3. **Synthetic Photometry**:
    - Calculate monochromatic and bolometric luminosities
    - Compute magnitudes in various photometric systems (e.g., AB, ST)
-   - Support for multiple standard filters (e.g., Johnson, Bessel, Gaia)
+   - Support for multiple standard filters (e.g., Johnson-Cousins, Gaia, 2MASS)
 
 4. **Binary System Modeling**:
-   - Simulate synthetic spectra and photometric for binary star systems
+   - Simulate synthetic spectra and photometry for binary star systems
    - Account for eclipsing
 
 5. **Data Visualization**:

--- a/docs/source/mesh.rst
+++ b/docs/source/mesh.rst
@@ -374,7 +374,7 @@ or by adding two circular spots:
         smoothness=jnp.array([0.5, 0.5]) # smoothness of the spot edges
     )
 
-This exampe adds two spots to the mesh. The spots are defined by their center in spherical coordinates, their radius, and a differential parameter that quantifies the change induced by the spot.
+This example adds two spots to the mesh. The spots are defined by their center in spherical coordinates, their radius, and a differential parameter that quantifies the change induced by the spot.
 
 .. image:: ../img/temp_two_spots_dark.png
    :width: 600

--- a/docs/source/mesh.rst
+++ b/docs/source/mesh.rst
@@ -11,7 +11,7 @@ To create a basic icosphere model, you can use the `IcosphereModel.construct()` 
 .. code-block:: python
 
     from spice.models import IcosphereModel
-    from transformer_payne import Blackbody
+    from spice.spectrum import Blackbody
 
     # Initialize a Blackbody model (for spectrum calculation)
     bb = Blackbody()

--- a/docs/source/synthetic_photometry.rst
+++ b/docs/source/synthetic_photometry.rst
@@ -45,10 +45,9 @@ SPICE includes utilities to calculate luminosity offsets for blackbody models wi
 .. code-block:: python
 
     from spice.models import IcosphereModel
-    from spice.spectrum import simulate_observed_flux, luminosity, absolute_bol_luminosity
+    from spice.spectrum import simulate_observed_flux, luminosity, absolute_bol_luminosity, Blackbody
     from spice.spectrum.filter import JohnsonCousinsB, JohnsonCousinsI, GaiaG, JohnsonCousinsV
     from spice.spectrum.spectrum import AB_passband_luminosity, ST_passband_luminosity
-    from transformer_payne import Blackbody
 
     def calculate_blackbody_luminosity(n_vertices):
         bb = Blackbody()


### PR DESCRIPTION
Small follow-up to #139 (this commit just missed the merge):

- `synthetic_photometry.rst` imported `Blackbody` from `transformer_payne`; it lives in `spice.spectrum`
- `index.rst`: Bessel filters were renamed to JohnsonCousins; mention 2MASS
- Fix photometric/exampe typos

Docs-only; no package impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)